### PR TITLE
Heli/Helipad migration script

### DIFF
--- a/migrations/Helicopters_0.0.5.lua
+++ b/migrations/Helicopters_0.0.5.lua
@@ -1,0 +1,31 @@
+require("logic.heliBase")
+require("logic.heliAttack")
+require("logic.heliPad")
+
+global.helis = {}
+global.heliPads = {}
+
+for _,surface in pairs(game.surfaces) do
+    cars = surface.find_entities_filtered{type = "car"}
+    for _,car in pairs(cars) do
+        if string.find(heliEntityNames, car.name .. ",", 1, true) then
+            if string.find(heliBaseEntityNames, car.name .. ",", 1, true) then
+                local driver = car.get_driver()
+                car.set_driver(nil)
+                local newHeli = insertInGlobal("helis", heliAttack.new(car))
+                if driver then newHeli.baseEnt.set_driver(driver) end
+            else
+                car.set_driver(nil)
+                car.destroy()
+            end
+        end
+    end
+
+    simples = surface.find_entities_filtered{type = "simple-entity-with-force"}
+    padNames = "heli-pad-placement-entity,heli-pad-entity,"
+    for _,simple in pairs(simples) do
+        if string.find(padNames, simple.name .. ",", 1, true) then
+            local newPad = insertInGlobal("heliPads", heliPad.new(simple))
+        end
+    end
+end


### PR DESCRIPTION
I have completed a step on the way to allowing the use of previously-built helicopters and pads without needing to completely remove both original and forked mods (thus losing all entities/items related to helicopters).

This is based on the `/fixchoppa` command from the "Choppers" fork, and extended to also handle helipads. It does _not_ yet restore the autopilot functionality; clicking things in the remote GUI causes no apparent errors, but also doesn't do anything.

Since this isn't actually complete, I'm opening it as a draft PR.