### PR TITLE
Make it work with recent Factorio versions again (>= 0.18.28)

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -37,8 +37,11 @@ function OnLoad(e)
 	if global.remoteGuis then
 		for _,remotegui in pairs(global.remoteGuis) do
 			for _,gui in pairs(remotegui.guis) do
-				if gui.setmeta then
-					gui:setmeta()
+				if gui.prefix then
+					local n = string.gsub(gui.prefix, "heli_(%a+)_.*", "%1")
+					if _G[n] then
+						setmetatable(gui, {__index = _G[n]})
+					end
 				end
 			end
 		end

--- a/logic/basicState.lua
+++ b/logic/basicState.lua
@@ -16,9 +16,10 @@ basicState =
 basicState.mt =
 {
 	__index = function(t, k)
-		if basicState[k] then
+		if stateFuncs[t.name] and stateFuncs[t.name][k] then
+			return stateFuncs[t.name][k]
+		elseif basicState[k] then
 			return basicState[k]
-
 		elseif type(k) == "string" and k:match("^On.+") then
 			return function()
 			end

--- a/logic/gui/heliPadSelectionGui.lua
+++ b/logic/gui/heliPadSelectionGui.lua
@@ -13,17 +13,10 @@ heliPadSelectionGui =
 			{
 				parent = mod_gui.get_frame_flow(p),
 			},
-
-			setmeta = function(self)
-				setmetatable(self, {__index = heliPadSelectionGui})
-			end,
-
+			prefix = "heli_heliPadSelectionGui_",
 		}
 
-		for k,v in pairs(heliPadSelectionGui) do
-			obj[k] = v
-		end
-
+		setmetatable(obj, {__index = heliPadSelectionGui})
 		obj:buildGui()
 
 		return obj

--- a/logic/gui/heliSelectionGui.lua
+++ b/logic/gui/heliSelectionGui.lua
@@ -13,12 +13,9 @@ heliSelectionGui =
 			{
 				parent = mod_gui.get_frame_flow(p),
 			},
+			prefix = "heli_heliSelectionGui_",
 
 			curCamID = 0,
-			
-			setmeta = function(self)
-				setmetatable(self, {__index = heliSelectionGui})
-			end,
 		}
 
 		setmetatable(obj, {__index = heliSelectionGui})

--- a/logic/gui/markerSelectionGui.lua
+++ b/logic/gui/markerSelectionGui.lua
@@ -16,15 +16,10 @@ markerSelectionGui =
 			},
 
 			curRefreshCooldown = markerSelectionGui.refreshCooldown,
-			
-			setmeta = function(self)
-				setmetatable(self, {__index = markerSelectionGui})
-			end,
+			prefix = "heli_markerSelectionGui_",
 		}
 
-		for k,v in pairs(markerSelectionGui) do
-			obj[k] = v
-		end
+		setmetatable(obj, {__index = markerSelectionGui})
 
 		obj:buildGui()
 

--- a/logic/gui/playerSelectionGui.lua
+++ b/logic/gui/playerSelectionGui.lua
@@ -16,7 +16,7 @@ playerSelectionGui =
 			prefix = "heli_playerSelectionGui_",
 		}
 
-		setmetatable(self, {__index = playerSelectionGui})
+		setmetatable(obj, {__index = playerSelectionGui})
 		obj:buildGui()
 
 		return obj

--- a/logic/gui/playerSelectionGui.lua
+++ b/logic/gui/playerSelectionGui.lua
@@ -13,16 +13,10 @@ playerSelectionGui =
 			{
 				parent = mod_gui.get_frame_flow(p),
 			},
-
-			setmeta = function(self)
-				setmetatable(self, {__index = playerSelectionGui})
-			end,
+			prefix = "heli_playerSelectionGui_",
 		}
 
-		for k,v in pairs(playerSelectionGui) do
-			obj[k] = v
-		end
-
+		setmetatable(self, {__index = playerSelectionGui})
 		obj:buildGui()
 
 		return obj


### PR DESCRIPTION
Factorio recently made a change (see [FFF-349](https://factorio.com/blog/post/fff-349)) that functions stored in (tables in) globals will be discarded when saving the game. Therefore they're no longer preset after loading the game again which breaks this mod.

This metatable restoration code for the GUI ~~isn't the most beautiful~~ is a somewhat ugly hack but the best way I found with my limited LUA skills/knowledge.