### PR TITLE
Options to disable biters damage while flying

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -390,6 +390,19 @@ function OnRuntimeSettingsChanged(e)
   end
 end
 
+-- raised when a helicopter is damaged
+function OnHeliDamaged(e)
+  local ent = e.entity
+
+  if ent.valid then
+    local entName = ent.name
+
+    if entName == "heli-entity-_-" then
+      getHeliFromBaseEntity(ent):OnDamaged(e)
+    end
+  end
+end
+
 script.on_event(defines.events.on_built_entity, OnBuilt)
 script.on_event(defines.events.on_robot_built_entity, OnBuilt)
 
@@ -400,6 +413,9 @@ script.on_event(defines.events.on_tick, OnTick)
 script.on_event(defines.events.on_player_mined_entity, OnRemoved)
 script.on_event(defines.events.on_robot_mined_entity, OnRemoved)
 script.on_event(defines.events.on_entity_died, OnRemoved)
+
+script.on_event(defines.events.on_entity_damaged, OnHeliDamaged)
+script.set_event_filter(defines.events.on_entity_damaged, {{filter = "name", name = "heli-entity-_-"}})
 
 script.on_event("heli-up", OnHeliUp)
 script.on_event("heli-down", OnHeliDown)

--- a/control.lua
+++ b/control.lua
@@ -18,376 +18,376 @@ Entity = require("stdlib.entity.entity")
 mod_gui = require("mod-gui")
 
 function playerIsInHeli(p)
-	return p.driving and string.find(heliBaseEntityNames, p.vehicle.name .. ",", 1, true)
+  return p.driving and string.find(heliBaseEntityNames, p.vehicle.name .. ",", 1, true)
 end
 
 function OnLoad(e)
-	if global.helis then
-		for _, heli in pairs(global.helis) do
-			if not heli.type or heli.type == "heliAttack" then
-				setmetatable(heli, {__index = heliAttack})
-			end
-		end
-	end
-	setMetatablesInGlobal("remoteGuis", {__index = remoteGui})
-	setMetatablesInGlobal("heliPads", {__index = heliPad})
-	setMetatablesInGlobal("heliControllers", {__index = heliController})
+  if global.helis then
+    for _, heli in pairs(global.helis) do
+      if not heli.type or heli.type == "heliAttack" then
+        setmetatable(heli, {__index = heliAttack})
+      end
+    end
+  end
+  setMetatablesInGlobal("remoteGuis", {__index = remoteGui})
+  setMetatablesInGlobal("heliPads", {__index = heliPad})
+  setMetatablesInGlobal("heliControllers", {__index = heliController})
 
-	--restore gui metatables
-	if global.remoteGuis then
-		for _,remotegui in pairs(global.remoteGuis) do
-			for _,gui in pairs(remotegui.guis) do
-				if gui.prefix then
-					local n = string.gsub(gui.prefix, "heli_(%a+)_.*", "%1")
-					if _G[n] then
-						setmetatable(gui, {__index = _G[n]})
-					end
-				end
-			end
-		end
-	end
+  --restore gui metatables
+  if global.remoteGuis then
+    for _,remotegui in pairs(global.remoteGuis) do
+      for _,gui in pairs(remotegui.guis) do
+        if gui.prefix then
+          local n = string.gsub(gui.prefix, "heli_(%a+)_.*", "%1")
+          if _G[n] then
+            setmetatable(gui, {__index = _G[n]})
+          end
+        end
+      end
+    end
+  end
 
-	callInGlobal("helis", "OnLoad")
+  callInGlobal("helis", "OnLoad")
 
-	mtMgr.OnLoad()
+  mtMgr.OnLoad()
 end
 
 function OnConfigChanged(e)
-	if global.helis then
-		for k, curHeli in pairs(global.helis) do
-			if not curHeli.curState then
-				if curHeli.goUp then
-					curHeli:changeState(curHeli.engineStarting)
-				else
-					curHeli:changeState(curHeli.descend)
-				end
-			end
+  if global.helis then
+    for k, curHeli in pairs(global.helis) do
+      if not curHeli.curState then
+        if curHeli.goUp then
+          curHeli:changeState(curHeli.engineStarting)
+        else
+          curHeli:changeState(curHeli.descend)
+        end
+      end
 
-			if not curHeli.surface then
-				curHeli.surface = curHeli.baseEnt.surface
-			end
+      if not curHeli.surface then
+        curHeli.surface = curHeli.baseEnt.surface
+      end
 
-			if not curHeli.type then
-				curHeli.type = "heliAttack"
-			end
+      if not curHeli.type then
+        curHeli.type = "heliAttack"
+      end
 
-			if curHeli.hasLandedCollider and not curHeli.childs.collisionEnt.valid then
-				curHeli:setCollider("landed")
-			end
+      if curHeli.hasLandedCollider and not curHeli.childs.collisionEnt.valid then
+        curHeli:setCollider("landed")
+      end
 
-			if not curHeli.deactivatedInserters then
-				curHeli.deactivatedInserters = {}
-			end
+      if not curHeli.deactivatedInserters then
+        curHeli.deactivatedInserters = {}
+      end
 
-			curHeli:reassignCurState()
-		end
-	end
+      curHeli:reassignCurState()
+    end
+  end
 
-	if global.heliPads then
-		for k, curPad in pairs(global.heliPads) do
-			if not curPad.surface then
-				curPad.surface = curPad.baseEnt.surface
-			end
-		end
-	end
+  if global.heliPads then
+    for k, curPad in pairs(global.heliPads) do
+      if not curPad.surface then
+        curPad.surface = curPad.baseEnt.surface
+      end
+    end
+  end
 
-	for k, p in pairs(game.players) do
-		local flow = mod_gui.get_button_flow(p)
+  for k, p in pairs(game.players) do
+    local flow = mod_gui.get_button_flow(p)
 
-		if flow.heli_remote_btn and flow.heli_remote_btn.valid then
-			flow.heli_remote_btn.destroy()
-		end
+    if flow.heli_remote_btn and flow.heli_remote_btn.valid then
+      flow.heli_remote_btn.destroy()
+    end
 
-		OnArmorInventoryChanged({player_index = p.index})
-		reSetGaugeGui(p)
-	end
+    OnArmorInventoryChanged({player_index = p.index})
+    reSetGaugeGui(p)
+  end
 
-	if global.heliControllers then
-		for k, curController in pairs(global.heliControllers) do
-			if not curController.heli.remoteController then
-				curController.heli.remoteController = curController
-			end
-		end
-	end
+  if global.heliControllers then
+    for k, curController in pairs(global.heliControllers) do
+      if not curController.heli.remoteController then
+        curController.heli.remoteController = curController
+      end
+    end
+  end
 
-	--fixing left open guis when saved
-	if global.remoteGuis then
-		global.remoteGuis = {}
-		for _,p in pairs(game.players) do
-			local flow = mod_gui.get_frame_flow(p)
-			if flow["heli_heliSelectionGui_rootFrame"] then
-				flow["heli_heliSelectionGui_rootFrame"].destroy()
-			end
-		end
-	end
+  --fixing left open guis when saved
+  if global.remoteGuis then
+    global.remoteGuis = {}
+    for _,p in pairs(game.players) do
+      local flow = mod_gui.get_frame_flow(p)
+      if flow["heli_heliSelectionGui_rootFrame"] then
+        flow["heli_heliSelectionGui_rootFrame"].destroy()
+      end
+    end
+  end
 end
 
 function OnTick(e)
-	checkAndTickInGlobal("helis")
-	checkAndTickInGlobal("remoteGuis")
-	checkAndTickInGlobal("heliControllers")
+  checkAndTickInGlobal("helis")
+  checkAndTickInGlobal("remoteGuis")
+  checkAndTickInGlobal("heliControllers")
 
-	OnTimerTick()
+  OnTimerTick()
 end
 
 function OnBuilt(e)
-	local ent = e.created_entity
+  local ent = e.created_entity
 
-	if ent.name == "heli-placement-entity-_-" then
-		local newHeli = insertInGlobal("helis", heliAttack.new(ent))
+  if ent.name == "heli-placement-entity-_-" then
+    local newHeli = insertInGlobal("helis", heliAttack.new(ent))
 
-		if global.remoteGuis then
-			for _,rg in pairs(global.remoteGuis) do
-				rg:OnHeliBuilt(newHeli)
-			end
-		end
+    if global.remoteGuis then
+      for _,rg in pairs(global.remoteGuis) do
+        rg:OnHeliBuilt(newHeli)
+      end
+    end
 
-	elseif ent.name == "heli-pad-placement-entity" then
-		local newPad = insertInGlobal("heliPads", heliPad.new(ent))
-		callInGlobal("remoteGuis", "OnHeliPadBuilt", newPad)
+  elseif ent.name == "heli-pad-placement-entity" then
+    local newPad = insertInGlobal("heliPads", heliPad.new(ent))
+    callInGlobal("remoteGuis", "OnHeliPadBuilt", newPad)
 
-	elseif ent.type == "inserter" then
-		ent.active = true
-	end
+  elseif ent.type == "inserter" then
+    ent.active = true
+  end
 end
 
 function OnRemoved(e)
-	local ent = e.entity
+  local ent = e.entity
 
-	if ent.valid then
-		local entName = ent.name
+  if ent.valid then
+    local entName = ent.name
 
-		if string.find(heliEntityNames, entName .. ",", 1, true) then
-			for i,val in ipairs(global.helis) do
-				if val:isBaseOrChild(ent) then
-					val:destroy()
-					table.remove(global.helis, i)
+    if string.find(heliEntityNames, entName .. ",", 1, true) then
+      for i,val in ipairs(global.helis) do
+        if val:isBaseOrChild(ent) then
+          val:destroy()
+          table.remove(global.helis, i)
 
-					if global.remoteGuis then
-						for _,rg in pairs(global.remoteGuis) do
-							rg:OnHeliRemoved(val)
-						end
-					end
-				end
-			end
-		end
+          if global.remoteGuis then
+            for _,rg in pairs(global.remoteGuis) do
+              rg:OnHeliRemoved(val)
+            end
+          end
+        end
+      end
+    end
 
-		if entName == "heli-pad-entity" then
-			local i = getHeliPadIndexFromBaseEntity(ent)
-			if i then
-				global.heliPads[i]:destroy()
+    if entName == "heli-pad-entity" then
+      local i = getHeliPadIndexFromBaseEntity(ent)
+      if i then
+        global.heliPads[i]:destroy()
 
-				callInGlobal("remoteGuis", "OnHeliPadRemoved", global.heliPads[i])
-				table.remove(global.heliPads, i)
-			end
-		end
-	end
+        callInGlobal("remoteGuis", "OnHeliPadRemoved", global.heliPads[i])
+        table.remove(global.heliPads, i)
+      end
+    end
+  end
 end
 
 function OnHeliUp(e)
-	local p = game.players[e.player_index]
-	if playerIsInHeli(p) then
-		getHeliFromBaseEntity(p.vehicle):OnUp()
-	end
+  local p = game.players[e.player_index]
+  if playerIsInHeli(p) then
+    getHeliFromBaseEntity(p.vehicle):OnUp()
+  end
 end
 
 function OnHeliDown(e)
-	local p = game.players[e.player_index]
-	if playerIsInHeli(p) then
-		getHeliFromBaseEntity(p.vehicle):OnDown()
-	end
+  local p = game.players[e.player_index]
+  if playerIsInHeli(p) then
+    getHeliFromBaseEntity(p.vehicle):OnDown()
+  end
 end
 
 function OnHeliIncreaseMaxHeight(e)
-	local p = game.players[e.player_index]
-	if playerIsInHeli(p) then
-		getHeliFromBaseEntity(p.vehicle):OnIncreaseMaxHeight()
-	end
+  local p = game.players[e.player_index]
+  if playerIsInHeli(p) then
+    getHeliFromBaseEntity(p.vehicle):OnIncreaseMaxHeight()
+  end
 end
 
 function OnHeliDecreaseMaxHeight(e)
-	local p = game.players[e.player_index]
-	if playerIsInHeli(p) then
-		getHeliFromBaseEntity(p.vehicle):OnDecreaseMaxHeight()
-	end
+  local p = game.players[e.player_index]
+  if playerIsInHeli(p) then
+    getHeliFromBaseEntity(p.vehicle):OnDecreaseMaxHeight()
+  end
 end
 
 function OnHeliToggleFloodlight(e)
-	local p = game.players[e.player_index]
-	if playerIsInHeli(p) then
-		getHeliFromBaseEntity(p.vehicle):OnToggleFloodlight()
-	end
+  local p = game.players[e.player_index]
+  if playerIsInHeli(p) then
+    getHeliFromBaseEntity(p.vehicle):OnToggleFloodlight()
+  end
 end
 
 function OnHeliFollow(e)
-	local p = game.players[e.player_index]
+  local p = game.players[e.player_index]
 
-	if playerHasEquipment(p, "heli-remote-equipment") then
-		local heli, dist = findNearestAvailableHeli(p.position, p.force, p)
+  if playerHasEquipment(p, "heli-remote-equipment") then
+    local heli, dist = findNearestAvailableHeli(p.position, p.force, p)
 
-		if heli then
-			assignHeliController(p, heli, p, true)
-			p.add_custom_alert(heli.baseEnt, {type = "item", name = "heli-item"}, {"heli-alert-follow", chopDecimal(dist)}, true)
-		end
-	end
+    if heli then
+      assignHeliController(p, heli, p, true)
+      p.add_custom_alert(heli.baseEnt, {type = "item", name = "heli-item"}, {"heli-alert-follow", chopDecimal(dist)}, true)
+    end
+  end
 end
 
 function OnRemoteOpen(e)
-	local p = game.players[e.player_index]
+  local p = game.players[e.player_index]
 
-	if playerHasEquipment(p, "heli-remote-equipment") then
-		toggleRemoteGui(p)
-	end
+  if playerHasEquipment(p, "heli-remote-equipment") then
+    toggleRemoteGui(p)
+  end
 end
 
 function OnPlacedEquipment(e)
-	if e.equipment.name == "heli-remote-equipment" then
-		local p = game.players[e.player_index]
+  if e.equipment.name == "heli-remote-equipment" then
+    local p = game.players[e.player_index]
 
-		setRemoteBtn(p, true)
-	end
+    setRemoteBtn(p, true)
+  end
 end
 
 function OnRemovedEquipment(e)
-	if e.equipment == "heli-remote-equipment" then
-		local p = game.players[e.player_index]
+  if e.equipment == "heli-remote-equipment" then
+    local p = game.players[e.player_index]
 
-		if not equipmentGridHasItem(e.grid, "heli-remote-equipment") then
-			setRemoteBtn(p, false)
-		end
-	end
+    if not equipmentGridHasItem(e.grid, "heli-remote-equipment") then
+      setRemoteBtn(p, false)
+    end
+  end
 end
 
 function OnArmorInventoryChanged(e)
-	local p = game.players[e.player_index]
+  local p = game.players[e.player_index]
 
-	if playerHasEquipment(p, "heli-remote-equipment") then
-		setRemoteBtn(p, true)
-	else
-		setRemoteBtn(p, false)
-	end
+  if playerHasEquipment(p, "heli-remote-equipment") then
+    setRemoteBtn(p, true)
+  else
+    setRemoteBtn(p, false)
+  end
 end
 
 function OnGuiClick(e)
-	local name = e.element.name
+  local name = e.element.name
 
-	if name:match("^heli_") then
-		local p = game.players[e.player_index]
+  if name:match("^heli_") then
+    local p = game.players[e.player_index]
 
-		if name == "heli_remote_btn" then
-			toggleRemoteGui(p)
+    if name == "heli_remote_btn" then
+      toggleRemoteGui(p)
 
-		elseif gaugeGui.hasMyPrefix(name) then
-			local i = searchIndexInTable(global.gaugeGuis, p, "player")
+    elseif gaugeGui.hasMyPrefix(name) then
+      local i = searchIndexInTable(global.gaugeGuis, p, "player")
 
-			if i then
-				global.gaugeGuis[i]:OnGuiClick(e)
-			end
+      if i then
+        global.gaugeGuis[i]:OnGuiClick(e)
+      end
 
-		elseif remoteGui.hasMyPrefix(name) then
-			local i = searchIndexInTable(global.remoteGuis, p, "player")
+    elseif remoteGui.hasMyPrefix(name) then
+      local i = searchIndexInTable(global.remoteGuis, p, "player")
 
-			if i then
-				global.remoteGuis[i]:OnGuiClick(e)
-			end
-		end
-	end
+      if i then
+        global.remoteGuis[i]:OnGuiClick(e)
+      end
+    end
+  end
 end
 
 function OnGuiTextChanged(e)
-	local name = e.element.name
+  local name = e.element.name
 
-	if name:match("^heli_") then
-		local p = game.players[e.player_index]
-		local i = searchIndexInTable(global.remoteGuis, p, "player")
+  if name:match("^heli_") then
+    local p = game.players[e.player_index]
+    local i = searchIndexInTable(global.remoteGuis, p, "player")
 
-		if i then
-			global.remoteGuis[i]:OnGuiTextChanged(e)
-		end
-	end
+    if i then
+      global.remoteGuis[i]:OnGuiTextChanged(e)
+    end
+  end
 end
 
 function OnPlayerChangedForce(e)
-	local p = game.players[e.player_index]
+  local p = game.players[e.player_index]
 
-	callInGlobal("remoteGuis", "OnPlayerChangedForce", p)
+  callInGlobal("remoteGuis", "OnPlayerChangedForce", p)
 end
 
 function OnPlayerDied(e)
-	local p = game.players[e.player_index]
+  local p = game.players[e.player_index]
 
-	setRemoteBtn(p, false)
+  setRemoteBtn(p, false)
 
-	callInGlobal("remoteGuis", "OnPlayerDied", p)
+  callInGlobal("remoteGuis", "OnPlayerDied", p)
 end
 
 function OnPlayerLeft(e)
-	local p = game.players[e.player_index]
-	local i = searchIndexInTable(global.remoteGuis, p, "player")
+  local p = game.players[e.player_index]
+  local i = searchIndexInTable(global.remoteGuis, p, "player")
 
-	if i then
-		global.remoteGuis[i]:destroy()
-		table.remove(global.remoteGuis, i)
-	end
+  if i then
+    global.remoteGuis[i]:destroy()
+    table.remove(global.remoteGuis, i)
+  end
 
-	callInGlobal("remoteGuis", "OnPlayerLeft", p)
+  callInGlobal("remoteGuis", "OnPlayerLeft", p)
 end
 
 function OnPlayerRespawned(e)
-	callInGlobal("remoteGuis", "OnPlayerRespawned", game.players[e.player_index])
+  callInGlobal("remoteGuis", "OnPlayerRespawned", game.players[e.player_index])
 end
 
 function OnDrivingStateChanged(e)
-	local p = game.players[e.player_index]
-	local ent = e.entity
+  local p = game.players[e.player_index]
+  local ent = e.entity
 
-	if ent then
-		local entName = ent.name
+  if ent then
+    local entName = ent.name
 
-		if string.find(heliEntityNames, entName .. ",", 1, true)  then
-			local heli
-			for i, curHeli in ipairs(global.helis) do
-				if curHeli:isBaseOrChild(ent) then
-					heli = curHeli
-					break
-				end
-			end
+    if string.find(heliEntityNames, entName .. ",", 1, true)  then
+      local heli
+      for i, curHeli in ipairs(global.helis) do
+        if curHeli:isBaseOrChild(ent) then
+          heli = curHeli
+          break
+        end
+      end
 
-			reSetGaugeGui(p)
+      reSetGaugeGui(p)
 
-			if not p.driving then
-				heli:OnPlayerEjected(p)
-			end
-		end
-	end
+      if not p.driving then
+        heli:OnPlayerEjected(p)
+      end
+    end
+  end
 end
 
 function OnPlayerJoined(e)
-	OnArmorInventoryChanged(e)
+  OnArmorInventoryChanged(e)
 end
 
 function OnPlayerCreated(e)
-	OnArmorInventoryChanged(e)
+  OnArmorInventoryChanged(e)
 end
 
 function OnRuntimeSettingsChanged(e)
-	local name = e.setting
+  local name = e.setting
 
-	if name:match("^heli-") then
-		local p = game.players[e.player_index]
+  if name:match("^heli-") then
+    local p = game.players[e.player_index]
 
-		if e.setting_type == "runtime-per-user" then
-			local val = p.mod_settings[name].value
+    if e.setting_type == "runtime-per-user" then
+      local val = p.mod_settings[name].value
 
-			if name == "heli-gaugeGui-show" then
-				reSetGaugeGui(p)
-			end
+      if name == "heli-gaugeGui-show" then
+        reSetGaugeGui(p)
+      end
 
-		--elseif e.setting_type == "runtime-global" then
-		--	local val = settings.global[name]
+    --elseif e.setting_type == "runtime-global" then
+    --  local val = settings.global[name]
 
-		end
-	end
+    end
+  end
 end
 
 script.on_event(defines.events.on_built_entity, OnBuilt)

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -1,17 +1,17 @@
 require("prototypes.tiles.heli-pad-concrete")
 
 if mods["Krastorio2"] then
-	-- copy K2 eqipment categories into heli-equipment-grid
-	data.raw["equipment-grid"]["heli-equipment-grid"].equipment_categories = data.raw["equipment-grid"]["kr-car-grid"].equipment_categories
+  -- copy K2 eqipment categories into heli-equipment-grid
+  data.raw["equipment-grid"]["heli-equipment-grid"].equipment_categories = data.raw["equipment-grid"]["kr-car-grid"].equipment_categories
 end
 
 if mods["VehicleGrid"] then
-	if mods["bobvehicleequipment"] then
-		-- copy Bob's equipment categories into heli-equipment-grid
-		data.raw["equipment-grid"]["heli-equipment-grid"].equipment_categories = data.raw["equipment-grid"]["bob-car"].equipment_categories
-	end
+  if mods["bobvehicleequipment"] then
+    -- copy Bob's equipment categories into heli-equipment-grid
+    data.raw["equipment-grid"]["heli-equipment-grid"].equipment_categories = data.raw["equipment-grid"]["bob-car"].equipment_categories
+  end
 end
 
 if mods["vtk-armor-plating"] then
-	table.insert(data.raw["equipment-grid"]["heli-equipment-grid"].equipment_categories, "vtk-armor-plating")
+  table.insert(data.raw["equipment-grid"]["heli-equipment-grid"].equipment_categories, "vtk-armor-plating")
   end

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -89,6 +89,9 @@ heli-flamethrower-damage-modifier=Flamethrower damage modifier
 heli-flamethrower-range=Flamethrower range
 heli-rocket-damage-modifier=Rocket damage modifier
 heli-rocket-launcher-range=Rocket launcher range
+heli-disable-biters-damage=Disable damage from biters (in flight)
+heli-disable-acid-splash-damage=Disable damage from acid puddles (in flight)
+heli-disable-direct-spitter-damage=Disable damage from spitter projectiles (in flight)
 heli-k2-anti-material-gun-damage-modifier=Anti-material gun damage modifier (Krastorio2)
 heli-k2-anti-material-gun-range=Anti-material gun range (Krastorio 2)
 

--- a/locale/ru/locale.cfg
+++ b/locale/ru/locale.cfg
@@ -86,6 +86,10 @@ heli-flamethrower-damage-modifier=Модификатор урона огнемё
 heli-consumption=Мощность разгона
 heli-braking-power=Сила торможения
 heli-weight=Вес вертолёта
+heli-disable-biters-damage=Отключить урон от кусак (в полете)
+heli-disable-acid-splash-damage=Отключить урон от луж кислоты (в полете)
+heli-disable-direct-spitter-damage=Отключить урон от плевка кислотой (в полете)
+
 
 [virtual-signal-name]
 signal-heli-fuel-warning=Малый уровень топлива

--- a/logic/basicAnimator.lua
+++ b/logic/basicAnimator.lua
@@ -1,141 +1,141 @@
 basicAnimator = 
 {
-	new = function(startValue, maxValue, durationInFrames, easingName)
-		local obj = 
-		{
-			curFrame = 0,
-			endFrame = durationInFrames - 1,
+  new = function(startValue, maxValue, durationInFrames, easingName)
+    local obj = 
+    {
+      curFrame = 0,
+      endFrame = durationInFrames - 1,
 
-			curVal = nil,
-			isDone = false,
+      curVal = nil,
+      isDone = false,
 
-			easingFunc = basicAnimator.easingFuncs[easingName],
+      easingFunc = basicAnimator.easingFuncs[easingName],
 
-			startValue = startValue,
-			--maxValue = maxValue,
-			delta = maxValue - startValue,
+      startValue = startValue,
+      --maxValue = maxValue,
+      delta = maxValue - startValue,
 
-			direction = 1,
-		}
+      direction = 1,
+    }
 
-		return setmetatable(obj, {__index = basicAnimator})
-	end,
+    return setmetatable(obj, {__index = basicAnimator})
+  end,
 
-	nextFrame = function(self)
-		local easedProgress = self.easingFunc(self.curFrame / self.endFrame)
+  nextFrame = function(self)
+    local easedProgress = self.easingFunc(self.curFrame / self.endFrame)
 
-		self.curVal = self.startValue + self.delta * easedProgress
+    self.curVal = self.startValue + self.delta * easedProgress
 
-		if self.directionChangeRate then
-			local oldDir = self.direction
-			self.direction = self.direction - self.directionChangeRate
+    if self.directionChangeRate then
+      local oldDir = self.direction
+      self.direction = self.direction - self.directionChangeRate
 
-			if self.bFadeOut then
-				if self.direction == 0 or (oldDir > 0 and self.direction < 0) or (oldDir < 0 and self.direction > 0) then
-					self.isDone = true
-				end
-			end
+      if self.bFadeOut then
+        if self.direction == 0 or (oldDir > 0 and self.direction < 0) or (oldDir < 0 and self.direction > 0) then
+          self.isDone = true
+        end
+      end
 
-			if self.direction >= 1 then
-				self.direction = 1
-				self.directionChangeRate = nil
+      if self.direction >= 1 then
+        self.direction = 1
+        self.directionChangeRate = nil
 
-			elseif self.direction <= -1 then
-				self.direction = -1
-				self.directionChangeRate = nil
-			end
-		end
+      elseif self.direction <= -1 then
+        self.direction = -1
+        self.directionChangeRate = nil
+      end
+    end
 
-		self.curFrame = self.curFrame + self.direction
-		if self.curFrame > self.endFrame or self.curFrame < 0 then
-			self.isDone = true
-		end
+    self.curFrame = self.curFrame + self.direction
+    if self.curFrame > self.endFrame or self.curFrame < 0 then
+      self.isDone = true
+    end
 
-		return self.curVal, self.isDone
-	end,
+    return self.curVal, self.isDone
+  end,
 
-	reset = function(self)
-		self.curVal = nil
-		self.isDone = false
-		self.curFrame = 0
-	end,
+  reset = function(self)
+    self.curVal = nil
+    self.isDone = false
+    self.curFrame = 0
+  end,
 
-	reverse = function(self)
-		self.direction = -1
-	end,
+  reverse = function(self)
+    self.direction = -1
+  end,
 
-	reverseSmoothly = function(self, maxSmoothingFrames)
-		if not maxSmoothingFrames then
-			maxSmoothingFrames = 20
-		end
+  reverseSmoothly = function(self, maxSmoothingFrames)
+    if not maxSmoothingFrames then
+      maxSmoothingFrames = 20
+    end
 
-		maxSmoothingFrames = math.min(maxSmoothingFrames, self:remainingFrames())
+    maxSmoothingFrames = math.min(maxSmoothingFrames, self:remainingFrames())
 
-		self.directionChangeRate = (self.direction / maxSmoothingFrames) * 2
-	end,
+    self.directionChangeRate = (self.direction / maxSmoothingFrames) * 2
+  end,
 
-	fadeOut = function(self, maxSmoothingFrames)
-		if maxSmoothingFrames then
-			maxSmoothingFrames = maxSmoothingFrames / 2
-		end
+  fadeOut = function(self, maxSmoothingFrames)
+    if maxSmoothingFrames then
+      maxSmoothingFrames = maxSmoothingFrames / 2
+    end
 
-		self:reverseSmoothly(maxSmoothingFrames)
-		self.bFadeOut = true
-	end,
+    self:reverseSmoothly(maxSmoothingFrames)
+    self.bFadeOut = true
+  end,
 
-	remainingFrames = function(self)
-		if direction == 1 then
-			return self.endFrame - self.curFrame + 1
-		else
-			return self.curFrame + 1
-		end
-	end,
+  remainingFrames = function(self)
+    if direction == 1 then
+      return self.endFrame - self.curFrame + 1
+    else
+      return self.curFrame + 1
+    end
+  end,
 
-	easingFuncs = 
-	{
-		--source: https://gist.github.com/gre/1650294
+  easingFuncs = 
+  {
+    --source: https://gist.github.com/gre/1650294
 
-		linear = function(x) return x end,
+    linear = function(x) return x end,
 
-		-- accelerating from zero velocity
-		easeInQuad = function(x) return x^2 end,
+    -- accelerating from zero velocity
+    easeInQuad = function(x) return x^2 end,
 
-		-- decelerating to zero velocity
-		easeOutQuad = function(x) return x*(2-x) end,
+    -- decelerating to zero velocity
+    easeOutQuad = function(x) return x*(2-x) end,
 
-		-- acceleration until halfway, then deceleration
-		easeInOutQuad = function(x) if x < 0.5 then return 2*x^2 else return -1+(4-2*x)*x end end,
+    -- acceleration until halfway, then deceleration
+    easeInOutQuad = function(x) if x < 0.5 then return 2*x^2 else return -1+(4-2*x)*x end end,
 
-		-- accelerating from zero velocity 
-		easeInCubic = function(x) return x^3 end,
+    -- accelerating from zero velocity 
+    easeInCubic = function(x) return x^3 end,
 
-		-- decelerating to zero velocity 
-		easeOutCubic = function(x) return (x-1)^3+1 end,
+    -- decelerating to zero velocity 
+    easeOutCubic = function(x) return (x-1)^3+1 end,
 
-		-- acceleration until halfway, then deceleration 
-		easeInOutCubic = function(x) if x < 0.5 then return 4*x^3 else return (x-1)*(2*x-2)*(2*x-2)+1 end end,
+    -- acceleration until halfway, then deceleration 
+    easeInOutCubic = function(x) if x < 0.5 then return 4*x^3 else return (x-1)*(2*x-2)*(2*x-2)+1 end end,
 
-		-- accelerating from zero velocity 
-		easeInQuart = function(x) return x^4 end,
+    -- accelerating from zero velocity 
+    easeInQuart = function(x) return x^4 end,
 
-		-- decelerating to zero velocity 
-		easeOutQuart = function(x) return 1-(x-1)^4 end,
+    -- decelerating to zero velocity 
+    easeOutQuart = function(x) return 1-(x-1)^4 end,
 
-		-- acceleration until halfway, then deceleration
-		easeInOutQuart = function(x) if x < 0.5 then return 8*x^4 else return 1-8*(x-1)^4 end end,
+    -- acceleration until halfway, then deceleration
+    easeInOutQuart = function(x) if x < 0.5 then return 8*x^4 else return 1-8*(x-1)^4 end end,
 
-		-- accelerating from zero velocity
-		easeInQuint = function(x) return x^5 end,
+    -- accelerating from zero velocity
+    easeInQuint = function(x) return x^5 end,
 
-		-- decelerating to zero velocity
-		easeOutQuint = function(x) return 1+(x-1)^5 end,
-			
-		-- acceleration until halfway, then deceleration 
-		easeInOutQuint = function(x) if x < 0.5 then return 16*x^5 else return 1+16*(1-x)^5 end end,
+    -- decelerating to zero velocity
+    easeOutQuint = function(x) return 1+(x-1)^5 end,
+      
+    -- acceleration until halfway, then deceleration 
+    easeInOutQuint = function(x) if x < 0.5 then return 16*x^5 else return 1+16*(1-x)^5 end end,
 
-		-- acceleration until halfway, then deceleration 
-		easeInOutSine = function(x) return (math.cos(x * math.pi) - 1) * -0.5 end,
+    -- acceleration until halfway, then deceleration 
+    easeInOutSine = function(x) return (math.cos(x * math.pi) - 1) * -0.5 end,
 
-		cyclicSine = function(x) return math.sin(2 * math.pi * x) end,
-	},
+    cyclicSine = function(x) return math.sin(2 * math.pi * x) end,
+  },
 }

--- a/logic/basicState.lua
+++ b/logic/basicState.lua
@@ -1,28 +1,28 @@
 basicState = 
 {
-	new = function(obj)
-		return setmetatable(obj, basicState.mt)
-	end,
+  new = function(obj)
+    return setmetatable(obj, basicState.mt)
+  end,
 
-	--placeholders to avoid errors when a state does not need them
-	init = function() --becoming the active state
-	end,
+  --placeholders to avoid errors when a state does not need them
+  init = function() --becoming the active state
+  end,
 
-	deinit = function() --no longer the active state
-	end,
-	----
+  deinit = function() --no longer the active state
+  end,
+  ----
 }
 
 basicState.mt =
 {
-	__index = function(t, k)
-		if stateFuncs[t.name] and stateFuncs[t.name][k] then
-			return stateFuncs[t.name][k]
-		elseif basicState[k] then
-			return basicState[k]
-		elseif type(k) == "string" and k:match("^On.+") then
-			return function()
-			end
-		end
-	end,
+  __index = function(t, k)
+    if stateFuncs[t.name] and stateFuncs[t.name][k] then
+      return stateFuncs[t.name][k]
+    elseif basicState[k] then
+      return basicState[k]
+    elseif type(k) == "string" and k:match("^On.+") then
+      return function()
+      end
+    end
+  end,
 }

--- a/logic/emptyBoxCollider.lua
+++ b/logic/emptyBoxCollider.lua
@@ -1,312 +1,312 @@
 emptyBoxCollider =
 {
-	new = function(options)
-		local obj =
-		{
-			_orientation = options.orientation or 0,
-			surface = options.surface,
-			position = getIndexedPos(options.position),
-			force = options.force,
+  new = function(options)
+    local obj =
+    {
+      _orientation = options.orientation or 0,
+      surface = options.surface,
+      position = getIndexedPos(options.position),
+      force = options.force,
 
-			boxHalfs = 
-			{
-				ends = options.boxLengths.ends / 2,
-				sides = options.boxLengths.sides / 2
-			},
-			childColliders = {},
-			childColliderOffsets = {},
-		}
+      boxHalfs = 
+      {
+        ends = options.boxLengths.ends / 2,
+        sides = options.boxLengths.sides / 2
+      },
+      childColliders = {},
+      childColliderOffsets = {},
+    }
 
-		if not obj.force then
-			obj.force = game.forces.enemy
-		end
+    if not obj.force then
+      obj.force = game.forces.enemy
+    end
 
-		obj.childColliders.top = obj.surface.create_entity{
-			name = options.nameEnds,
-			force = obj.force,
-			position = obj.position,
-		}
+    obj.childColliders.top = obj.surface.create_entity{
+      name = options.nameEnds,
+      force = obj.force,
+      position = obj.position,
+    }
 
-		obj.childColliders.bottom = obj.surface.create_entity{
-			name = options.nameEnds,
-			force = obj.force,
-			position = obj.position,
-		}
+    obj.childColliders.bottom = obj.surface.create_entity{
+      name = options.nameEnds,
+      force = obj.force,
+      position = obj.position,
+    }
 
-		obj.childColliders.left = obj.surface.create_entity{
-			name = options.nameSides,
-			force = obj.force,
-			position = obj.position,
-		}
+    obj.childColliders.left = obj.surface.create_entity{
+      name = options.nameSides,
+      force = obj.force,
+      position = obj.position,
+    }
 
-		obj.childColliders.right = obj.surface.create_entity{
-			name = options.nameSides,
-			force = obj.force,
-			position = obj.position,
-		}
+    obj.childColliders.right = obj.surface.create_entity{
+      name = options.nameSides,
+      force = obj.force,
+      position = obj.position,
+    }
 
-		setmetatable(obj, emptyBoxCollider.mt)
-		obj.setOrientation(obj._orientation)
+    setmetatable(obj, emptyBoxCollider.mt)
+    obj.setOrientation(obj._orientation)
 
-		return obj
-	end,
+    return obj
+  end,
 
-	destroy = function(self)
-		for k,v in pairs(self.childColliders) do
-			if v.valid then
-				v.destroy()
-			end
-		end
-	end,
+  destroy = function(self)
+    for k,v in pairs(self.childColliders) do
+      if v.valid then
+        v.destroy()
+      end
+    end
+  end,
 
-	valid = function(self)
-		local val = true
+  valid = function(self)
+    local val = true
 
-		for k,v in pairs(self.childColliders) do
-			if not v.valid then
-				val = false
-				break
-			end
-		end
+    for k,v in pairs(self.childColliders) do
+      if not v.valid then
+        val = false
+        break
+      end
+    end
 
-		if not val then
-			self.destroy()
-		end
+    if not val then
+      self.destroy()
+    end
 
-		return val
-	end,
+    return val
+  end,
 
-	moveChildColliders = function(self)
-		self.childColliders.top.teleport(math3d.vector2.add(self.position, self.childColliderOffsets.up))
-		self.childColliders.bottom.teleport(math3d.vector2.sub(self.position, self.childColliderOffsets.up))
+  moveChildColliders = function(self)
+    self.childColliders.top.teleport(math3d.vector2.add(self.position, self.childColliderOffsets.up))
+    self.childColliders.bottom.teleport(math3d.vector2.sub(self.position, self.childColliderOffsets.up))
 
-		self.childColliders.right.teleport(math3d.vector2.add(self.position, self.childColliderOffsets.right))
-		self.childColliders.left.teleport(math3d.vector2.sub(self.position, self.childColliderOffsets.right))
-	end,
+    self.childColliders.right.teleport(math3d.vector2.add(self.position, self.childColliderOffsets.right))
+    self.childColliders.left.teleport(math3d.vector2.sub(self.position, self.childColliderOffsets.right))
+  end,
 
-	setOrientation = function(self, orient)
-		self._orientation = orient
+  setOrientation = function(self, orient)
+    self._orientation = orient
 
-		self.childColliderOffsets.up = math3d.vector2.rotate({0,self.boxHalfs.sides}, math.pi * 2 * orient)
-		self.childColliderOffsets.right = math3d.vector2.rotate({self.boxHalfs.ends,0}, math.pi * 2 * orient)
+    self.childColliderOffsets.up = math3d.vector2.rotate({0,self.boxHalfs.sides}, math.pi * 2 * orient)
+    self.childColliderOffsets.right = math3d.vector2.rotate({self.boxHalfs.ends,0}, math.pi * 2 * orient)
 
-		for k,v in pairs(self.childColliders) do
-			v.orientation = orient
-		end
+    for k,v in pairs(self.childColliders) do
+      v.orientation = orient
+    end
 
-		self.moveChildColliders()
-	end,
+    self.moveChildColliders()
+  end,
 
-	teleport = function(self, pos)
-		self.position = getIndexedPos(pos)
+  teleport = function(self, pos)
+    self.position = getIndexedPos(pos)
 
-		self.moveChildColliders()
-	end,
+    self.moveChildColliders()
+  end,
 
-	getHealth = function(self)
-		local lowest = self.childColliders.top.health
+  getHealth = function(self)
+    local lowest = self.childColliders.top.health
 
-		for k,v in pairs(self.childColliders) do
-			if v.health < lowest then
-				lowest = v.health
-			end
-		end
+    for k,v in pairs(self.childColliders) do
+      if v.health < lowest then
+        lowest = v.health
+      end
+    end
 
-		return lowest
-	end,
+    return lowest
+  end,
 
-	setHealth = function(self, health)
-		for k,v in pairs(self.childColliders) do
-			v.health = health
-		end
-	end,
+  setHealth = function(self, health)
+    for k,v in pairs(self.childColliders) do
+      v.health = health
+    end
+  end,
 
-	getSpeed = function(self)
-		local highest = self.childColliders.top.speed
+  getSpeed = function(self)
+    local highest = self.childColliders.top.speed
 
-		for k,v in pairs(self.childColliders) do
-			if v.speed > highest then
-				speed = v.speed
-			end
-		end
+    for k,v in pairs(self.childColliders) do
+      if v.speed > highest then
+        speed = v.speed
+      end
+    end
 
-		return highest
-	end,
+    return highest
+  end,
 
-	setSpeed = function(self, speed)
-		for k,v in pairs(self.childColliders) do
-			v.speed = speed
-		end
-	end,
+  setSpeed = function(self, speed)
+    for k,v in pairs(self.childColliders) do
+      v.speed = speed
+    end
+  end,
 
-	setOperable = function(self, operable)
-		for k,v in pairs(self.childColliders) do
-			v.operable = operable
-		end
-	end,
+  setOperable = function(self, operable)
+    for k,v in pairs(self.childColliders) do
+      v.operable = operable
+    end
+  end,
 
-	get_driver = function(self)
-		for k,v in pairs(self.childColliders) do
-			local driver = v.get_driver()
-			if driver then
-				return driver
-			end
-		end
+  get_driver = function(self)
+    for k,v in pairs(self.childColliders) do
+      local driver = v.get_driver()
+      if driver then
+        return driver
+      end
+    end
 
-		return nil
-	end,
+    return nil
+  end,
 
-	set_driver = function(self, driver)
-		if driver == nil then
-			for k,v in pairs(self.childColliders) do
-				v.set_driver(nil)
-			end
-		end
-	end,
+  set_driver = function(self, driver)
+    if driver == nil then
+      for k,v in pairs(self.childColliders) do
+        v.set_driver(nil)
+      end
+    end
+  end,
 
-	get_passenger = function(self)
-		for k,v in pairs(self.childColliders) do
-			local passenger = v.get_passenger()
-			if passenger then
-				return passenger
-			end
-		end
+  get_passenger = function(self)
+    for k,v in pairs(self.childColliders) do
+      local passenger = v.get_passenger()
+      if passenger then
+        return passenger
+      end
+    end
 
-		return nil
-	end,
+    return nil
+  end,
 
-	set_passenger = function(self, passenger)
-		if passenger == nil then
-			for k,v in pairs(self.childColliders) do
-				v.set_passenger(nil)
-			end
-		end
-	end,
+  set_passenger = function(self, passenger)
+    if passenger == nil then
+      for k,v in pairs(self.childColliders) do
+        v.set_passenger(nil)
+      end
+    end
+  end,
 
-	isPosInside = function(self, pos)
-		local delta = math3d.vector2.sub(getIndexedPos(pos), self.position)
+  isPosInside = function(self, pos)
+    local delta = math3d.vector2.sub(getIndexedPos(pos), self.position)
 
-		local tX = delta[1]
-		local tY = delta[2]
+    local tX = delta[1]
+    local tY = delta[2]
 
-		local up = math3d.vector2.mul(self.childColliderOffsets.up, 1.1)
-		local right = math3d.vector2.mul(self.childColliderOffsets.right, 1.1)
+    local up = math3d.vector2.mul(self.childColliderOffsets.up, 1.1)
+    local right = math3d.vector2.mul(self.childColliderOffsets.right, 1.1)
 
-		local b1X = up[1]
-		local b1Y = up[2]
+    local b1X = up[1]
+    local b1Y = up[2]
 
-		local b2X = right[1]
-		local b2Y = right[2]
+    local b2X = right[1]
+    local b2Y = right[2]
 
-		--https://i.imgur.com/zQrgq0B.png
-		local a = (tY * b2X - tX * b2Y) / (b1Y * b2X - b1X * b2Y)
-		local b = (tY * b1X - tX * b1Y) / (b2Y * b1X - b2X * b1Y)
+    --https://i.imgur.com/zQrgq0B.png
+    local a = (tY * b2X - tX * b2Y) / (b1Y * b2X - b1X * b2Y)
+    local b = (tY * b1X - tX * b1Y) / (b2Y * b1X - b2X * b1Y)
 
-		return math.abs(a) < 1 and math.abs(b) < 1, a, b
-	end,
+    return math.abs(a) < 1 and math.abs(b) < 1, a, b
+  end,
 
-	ejectPlayers = function(self)
-		local rad = math.ceil(math.sqrt(self.boxHalfs.ends^2 + self.boxHalfs.sides^2))
-		local x = self.position[1]
-		local y = self.position[2]
+  ejectPlayers = function(self)
+    local rad = math.ceil(math.sqrt(self.boxHalfs.ends^2 + self.boxHalfs.sides^2))
+    local x = self.position[1]
+    local y = self.position[2]
 
-		local players = self.surface.find_entities_filtered{
-			area = {{x - rad, y - rad}, {x + rad, y + rad}},
-			type = "character",
-		}
+    local players = self.surface.find_entities_filtered{
+      area = {{x - rad, y - rad}, {x + rad, y + rad}},
+      type = "character",
+    }
 
-		for k, curPlayer in pairs(players) do
-			local pos = getIndexedPos(curPlayer.position)
-			local inside, a, b = self.isPosInside(pos)
+    for k, curPlayer in pairs(players) do
+      local pos = getIndexedPos(curPlayer.position)
+      local inside, a, b = self.isPosInside(pos)
 
-			if inside then
-				local deltaVec
-				if math.abs(a) > math.abs(b) then
-					local delta
-					if a > 0 then
-						delta = 1.2 - a
-					else
-						delta = -1.2 - a
-					end
+      if inside then
+        local deltaVec
+        if math.abs(a) > math.abs(b) then
+          local delta
+          if a > 0 then
+            delta = 1.2 - a
+          else
+            delta = -1.2 - a
+          end
 
-					deltaVec = math3d.vector2.mul(self.childColliderOffsets.up, delta)
-				else
-					local delta
-					if b > 0 then
-						delta = 1.2 - b
-					else
-						delta = -1.2 - b
-					end
-					
-					deltaVec = math3d.vector2.mul(self.childColliderOffsets.right, delta)
-				end
+          deltaVec = math3d.vector2.mul(self.childColliderOffsets.up, delta)
+        else
+          local delta
+          if b > 0 then
+            delta = 1.2 - b
+          else
+            delta = -1.2 - b
+          end
+          
+          deltaVec = math3d.vector2.mul(self.childColliderOffsets.right, delta)
+        end
 
-				curPlayer.teleport(math3d.vector2.add(pos, deltaVec))
-			end
-		end
-	end,
+        curPlayer.teleport(math3d.vector2.add(pos, deltaVec))
+      end
+    end
+  end,
 
-	isChildEntity = function(self, ent)
-		for k,v in pairs(self.childColliders) do
-			if v == ent then
-				return true
-			end
-		end
+  isChildEntity = function(self, ent)
+    for k,v in pairs(self.childColliders) do
+      if v == ent then
+        return true
+      end
+    end
 
-		return false
-	end,
+    return false
+  end,
 }
 
 emptyBoxCollider.mt =
 {
-	__index = function(t, k)
-		if k == "valid" then
-			return emptyBoxCollider.valid(t)
+  __index = function(t, k)
+    if k == "valid" then
+      return emptyBoxCollider.valid(t)
 
-		elseif k == "orientation" then
-			return t._orientation
+    elseif k == "orientation" then
+      return t._orientation
 
-		elseif k == "health" then
-			return emptyBoxCollider.getHealth(t)
+    elseif k == "health" then
+      return emptyBoxCollider.getHealth(t)
 
-		elseif k == "speed" then
-			return emptyBoxCollider.getSpeed(t)
+    elseif k == "speed" then
+      return emptyBoxCollider.getSpeed(t)
 
-		elseif k == "get_inventory" then
-			return function(...)
-				local params = {...}
-				return setmetatable({}, 
-					{__index = function(_t, _k)
-						return function(...)
-							for key, curCol in pairs(t.childColliders) do
-								curCol[k](unpack(params))[_k](...)
-							end
-						end
-					end})
-			end
+    elseif k == "get_inventory" then
+      return function(...)
+        local params = {...}
+        return setmetatable({}, 
+          {__index = function(_t, _k)
+            return function(...)
+              for key, curCol in pairs(t.childColliders) do
+                curCol[k](unpack(params))[_k](...)
+              end
+            end
+          end})
+      end
 
-		elseif type(emptyBoxCollider[k]) == "function" then
-			return function(...)
-				return emptyBoxCollider[k](t, ...)
-			end
+    elseif type(emptyBoxCollider[k]) == "function" then
+      return function(...)
+        return emptyBoxCollider[k](t, ...)
+      end
 
-		else
-			return emptyBoxCollider[k]
-		end
-	end,
+    else
+      return emptyBoxCollider[k]
+    end
+  end,
 
-	__newindex = function(t, k, v)
-		if k == "orientation" then
-			emptyBoxCollider.setOrientation(t, v)
+  __newindex = function(t, k, v)
+    if k == "orientation" then
+      emptyBoxCollider.setOrientation(t, v)
 
-		elseif k == "health" then
-			emptyBoxCollider.setHealth(t, v)
+    elseif k == "health" then
+      emptyBoxCollider.setHealth(t, v)
 
-		elseif k == "speed" then
-			emptyBoxCollider.setSpeed(t, v)
+    elseif k == "speed" then
+      emptyBoxCollider.setSpeed(t, v)
 
-		elseif k == "operable" then
-			emptyBoxCollider.setOperable(t, v)
-		end
-	end,
+    elseif k == "operable" then
+      emptyBoxCollider.setOperable(t, v)
+    end
+  end,
 }

--- a/logic/gui/gaugeGui.lua
+++ b/logic/gui/gaugeGui.lua
@@ -1,316 +1,316 @@
 function reSetGaugeGui(p)
-	local gg = searchInTable(global.gaugeGuis, p, "player")
+  local gg = searchInTable(global.gaugeGuis, p, "player")
 
-	local shouldHaveGG = playerIsInHeli(p) and p.mod_settings["heli-gaugeGui-show"].value
+  local shouldHaveGG = playerIsInHeli(p) and p.mod_settings["heli-gaugeGui-show"].value
 
-	if gg and not shouldHaveGG then
-		gg:destroy()
+  if gg and not shouldHaveGG then
+    gg:destroy()
 
-	elseif not gg and shouldHaveGG then
-		local heli = getHeliFromBaseEntity(p.vehicle)
-		if heli then
-			insertInGlobal("gaugeGuis", gaugeGui.new(p, heli))
-		end
-	end
+  elseif not gg and shouldHaveGG then
+    local heli = getHeliFromBaseEntity(p.vehicle)
+    if heli then
+      insertInGlobal("gaugeGuis", gaugeGui.new(p, heli))
+    end
+  end
 end
 
 local pointerFrames = 128
 
 gaugeGui =
 {
-	prefix = "heli_gaugeGui_",
+  prefix = "heli_gaugeGui_",
 
-	pointerData =
-	{
-		fuel = 
-		{
-			min = 0,
-			max = 1,
-			fMin = 0.375 * pointerFrames,
-			fMax = 0.625 * pointerFrames,
-			clockwise = true,
-		},
+  pointerData =
+  {
+    fuel = 
+    {
+      min = 0,
+      max = 1,
+      fMin = 0.375 * pointerFrames,
+      fMax = 0.625 * pointerFrames,
+      clockwise = true,
+    },
 
-		speed = 
-		{
-			min = 0,
-			max = 400,
-			fMin = 0.75 * pointerFrames,
-			fMax = 1.25 * pointerFrames,
-			clockwise = true,
-		},
+    speed = 
+    {
+      min = 0,
+      max = 400,
+      fMin = 0.75 * pointerFrames,
+      fMax = 1.25 * pointerFrames,
+      clockwise = true,
+    },
 
-		height = 
-		{
-			min = 0,
-			max = 25,
-			fMin = 0.5390625 * pointerFrames,
-			fMax = 0.965 * pointerFrames,
-			clockwise = true,
-		},
+    height = 
+    {
+      min = 0,
+      max = 25,
+      fMin = 0.5390625 * pointerFrames,
+      fMax = 0.965 * pointerFrames,
+      clockwise = true,
+    },
 
-		rpm = 
-		{
-			min = 0,
-			max = 3000,
-			fMin = 0.4609375 * pointerFrames,
-			fMax = 0.035 * pointerFrames,
-			clockwise = false,
-		},
-	},
+    rpm = 
+    {
+      min = 0,
+      max = 3000,
+      fMin = 0.4609375 * pointerFrames,
+      fMax = 0.035 * pointerFrames,
+      clockwise = false,
+    },
+  },
 
-	new = function(player, heli)
-		obj = 
-		{
-			valid = true,
-			player = player,
-			heli = heli,
+  new = function(player, heli)
+    obj = 
+    {
+      valid = true,
+      player = player,
+      heli = heli,
 
-			guiElems = 
-			{
-				parent = mod_gui.get_frame_flow(player),
-			},
-		}
+      guiElems = 
+      {
+        parent = mod_gui.get_frame_flow(player),
+      },
+    }
 
-		mtMgr.set(obj, "gaugeGui")
+    mtMgr.set(obj, "gaugeGui")
 
-		obj:buildGui()
-		heli:addGaugeGui(obj)
+    obj:buildGui()
+    heli:addGaugeGui(obj)
 
-		return obj
-	end,
+    return obj
+  end,
 
-	destroy = function(self)
-		self.valid = false
-	
-		if self.guiElems.root and self.guiElems.root.valid then
-			self.guiElems.root.destroy()
-		end
+  destroy = function(self)
+    self.valid = false
+  
+    if self.guiElems.root and self.guiElems.root.valid then
+      self.guiElems.root.destroy()
+    end
 
-		if self.heli.removeGaugeGui then
-			self.heli:removeGaugeGui(self)
-		end
+    if self.heli.removeGaugeGui then
+      self.heli:removeGaugeGui(self)
+    end
 
-		removeInGlobal("gaugeGuis", self)
-	end,
+    removeInGlobal("gaugeGuis", self)
+  end,
 
-	hasMyPrefix = function(str)
-		return string.startswith(str, gaugeGui.prefix)
-	end,
+  hasMyPrefix = function(str)
+    return string.startswith(str, gaugeGui.prefix)
+  end,
 
-	OnGuiClick = function(self, e)
-		local name = e.element.name
+  OnGuiClick = function(self, e)
+    local name = e.element.name
 
-		if name == self.prefix .. "speaker_on_button" then
-			self:setMuted(true)
-		
-		elseif name == self.prefix .. "speaker_off_button" then
-			self:setMuted(false)
-		end
-	end,
+    if name == self.prefix .. "speaker_on_button" then
+      self:setMuted(true)
+    
+    elseif name == self.prefix .. "speaker_off_button" then
+      self:setMuted(false)
+    end
+  end,
 
-	setMuted = function(self, muted)
-		local els = self.guiElems
-		local s = "on"
-		if muted then s = "off" end
+  setMuted = function(self, muted)
+    local els = self.guiElems
+    local s = "on"
+    if muted then s = "off" end
 
-		self.muted = muted
-		Entity.set_data(self.player, muted, "gaugeGui_muted")
+    self.muted = muted
+    Entity.set_data(self.player, muted, "gaugeGui_muted")
 
-		els.gauge_hr.speakerButtonFlow.clear()
+    els.gauge_hr.speakerButtonFlow.clear()
 
-		els.gauge_hr.speaker_button = els.gauge_hr.speakerButtonFlow.add
-		{
-			type = "button",
-			name = self.prefix .. "speaker_" .. s .. "_button",
-			style = "heli-speaker_" .. s .. "_button",
-		}
-	end,
+    els.gauge_hr.speaker_button = els.gauge_hr.speakerButtonFlow.add
+    {
+      type = "button",
+      name = self.prefix .. "speaker_" .. s .. "_button",
+      style = "heli-speaker_" .. s .. "_button",
+    }
+  end,
 
-	setGauge = function(self, gaugeName, pointerName, val)
-		local pD = self.pointerData[pointerName]
-		local pointer = self.guiElems[gaugeName].pointers[pointerName]
+  setGauge = function(self, gaugeName, pointerName, val)
+    local pD = self.pointerData[pointerName]
+    local pointer = self.guiElems[gaugeName].pointers[pointerName]
 
-		if pointer.noise then
-			val = val + pointer.noise:advance()
-		end
+    if pointer.noise then
+      val = val + pointer.noise:advance()
+    end
 
-		if pointer.lastVal ~= val then
-			pointer.lastVal = val
+    if pointer.lastVal ~= val then
+      pointer.lastVal = val
 
-			local pc = math.min(math.max(val / (pD.max - pD.min), 0), 1)
-			local frameDelta = math.abs(pD.fMax - pD.fMin)
+      local pc = math.min(math.max(val / (pD.max - pD.min), 0), 1)
+      local frameDelta = math.abs(pD.fMax - pD.fMin)
 
-			local frame
-			if pD.clockwise then
-				frame = pD.fMin + pc * frameDelta
-			else
-				frame = pD.fMin - pc * frameDelta
-			end
+      local frame
+      if pD.clockwise then
+        frame = pD.fMin + pc * frameDelta
+      else
+        frame = pD.fMin - pc * frameDelta
+      end
 
-			if frame < 0 then
-				frame = pointerFrames + frame
-			end
-			frame = math.floor(frame % pointerFrames)
+      if frame < 0 then
+        frame = pointerFrames + frame
+      end
+      frame = math.floor(frame % pointerFrames)
 
-			if pointer.lastFrame ~= frame then
-				pointer.lastFrame = frame
+      if pointer.lastFrame ~= frame then
+        pointer.lastFrame = frame
 
-				if pointer.elem then
-					pointer.elem.destroy() 
-				end
+        if pointer.elem then
+          pointer.elem.destroy() 
+        end
 
-				pointer.elem = pointer.root.add
-				{
-					type = "sprite",
-					name = gaugeName .. "_pointer_" .. pointerName,
-					sprite = "heli_gauge_pointer_" .. frame,
-					tooltip = {"heli-gui-gauges-tt"},
-				}
-			end
-		end
-	end,
+        pointer.elem = pointer.root.add
+        {
+          type = "sprite",
+          name = gaugeName .. "_pointer_" .. pointerName,
+          sprite = "heli_gauge_pointer_" .. frame,
+          tooltip = {"heli-gui-gauges-tt"},
+        }
+      end
+    end
+  end,
 
-	setLed = function(self, gaugeName, ledName, on)
-		local led = self.guiElems[gaugeName].leds[ledName]
+  setLed = function(self, gaugeName, ledName, on)
+    local led = self.guiElems[gaugeName].leds[ledName]
 
-		if led.elem then
-			led.elem.destroy()
-		end
+    if led.elem then
+      led.elem.destroy()
+    end
 
-		if on then
-			local fullName = gaugeName .. "_led_" .. ledName
+    if on then
+      local fullName = gaugeName .. "_led_" .. ledName
 
-			led.elem = self.guiElems[gaugeName].leds.root.add
-			{
-				type = "sprite",
-				name = self.prefix .. fullName,
-				sprite = "heli_" .. fullName,
-			}
-		end
+      led.elem = self.guiElems[gaugeName].leds.root.add
+      {
+        type = "sprite",
+        name = self.prefix .. fullName,
+        sprite = "heli_" .. fullName,
+      }
+    end
 
-		led.on = on
-	end,
+    led.on = on
+  end,
 
-	setLedBlinking = function(self, gaugeName, ledName, on, interval, sound)
-		local led = self.guiElems[gaugeName].leds[ledName]
-		
-		if not on then
-			led.sound = nil
+  setLedBlinking = function(self, gaugeName, ledName, on, interval, sound)
+    local led = self.guiElems[gaugeName].leds[ledName]
+    
+    if not on then
+      led.sound = nil
 
-			if led.blinkInterval then
-				led.blinkInterval:cancel()
-				led.blinkInterval = nil
-				self:setLed("gauge_fs", "fuel", false)
-			end
+      if led.blinkInterval then
+        led.blinkInterval:cancel()
+        led.blinkInterval = nil
+        self:setLed("gauge_fs", "fuel", false)
+      end
 
-		else
-			led.sound = sound
+    else
+      led.sound = sound
 
-			if not led.blinkInterval then
-				led.blinkInterval = setInterval(function(timer)
-				    local gg = timer.data.gg
-				    local _led = timer.data.led
+      if not led.blinkInterval then
+        led.blinkInterval = setInterval(function(timer)
+            local gg = timer.data.gg
+            local _led = timer.data.led
 
-					if not gg.valid then
-						timer:cancel()
+          if not gg.valid then
+            timer:cancel()
 
-					else
-						gg:setLed("gauge_fs", "fuel", not _led.on)
+          else
+            gg:setLed("gauge_fs", "fuel", not _led.on)
 
-						if _led.sound and (not gg.muted) and gg.player.mod_settings["heli-gaugeGui-play-fuel-warning-sound"].value then
-							gg.player.play_sound{path = _led.sound}
-						end
-					end
-				end, interval, {gg = self, led = led})
-			else
-				led.blinkInterval.interval = interval
-			end
-		end
-	end,
+            if _led.sound and (not gg.muted) and gg.player.mod_settings["heli-gaugeGui-play-fuel-warning-sound"].value then
+              gg.player.play_sound{path = _led.sound}
+            end
+          end
+        end, interval, {gg = self, led = led})
+      else
+        led.blinkInterval.interval = interval
+      end
+    end
+  end,
 
-	setPointerNoise = function(self, gaugeName, pointerName, enable, magnitude, timeAdvance, minFrequency, maxFrequency)
-		local pointer = self.guiElems[gaugeName].pointers[pointerName]
+  setPointerNoise = function(self, gaugeName, pointerName, enable, magnitude, timeAdvance, minFrequency, maxFrequency)
+    local pointer = self.guiElems[gaugeName].pointers[pointerName]
 
-		if enable then
-			pointer.noise = simpleNoise.new(magnitude, timeAdvance, minFrequency, maxFrequency)
+    if enable then
+      pointer.noise = simpleNoise.new(magnitude, timeAdvance, minFrequency, maxFrequency)
 
-		else
-			pointer.noise = nil
-		end
-	end,
+    else
+      pointer.noise = nil
+    end
+  end,
 
-	buildGauge = function(self, parent, name, pointerNames, ledNames)
-		local gauge = 
-		{
-			elem = parent.add
-			{
-				type = "sprite",
-				name = self.prefix .. name,
-				sprite = "heli_" .. name,
-			},
+  buildGauge = function(self, parent, name, pointerNames, ledNames)
+    local gauge = 
+    {
+      elem = parent.add
+      {
+        type = "sprite",
+        name = self.prefix .. name,
+        sprite = "heli_" .. name,
+      },
 
-			pointers = {},
-		}
+      pointers = {},
+    }
 
-		gauge.leds =
-		{
-			root = gauge.elem.add
-			{
-				type = "sprite",
-				name = self.prefix .. name .. "_ledRoot",
-				sprite = "heli_void_128",
-			},
-		}
+    gauge.leds =
+    {
+      root = gauge.elem.add
+      {
+        type = "sprite",
+        name = self.prefix .. name .. "_ledRoot",
+        sprite = "heli_void_128",
+      },
+    }
 
-		for k,v in pairs(pointerNames or {}) do
-			gauge.pointers[v] = 
-			{
-				root = gauge.elem.add
-				{
-					type = "sprite",
-					name = self.prefix .. name .. "_pointer_" .. v .. "_root",
-					sprite = "heli_void_128",
-				}
-			}
-		end
+    for k,v in pairs(pointerNames or {}) do
+      gauge.pointers[v] = 
+      {
+        root = gauge.elem.add
+        {
+          type = "sprite",
+          name = self.prefix .. name .. "_pointer_" .. v .. "_root",
+          sprite = "heli_void_128",
+        }
+      }
+    end
 
-		for k,v in pairs(ledNames or {}) do
-			gauge.leds[v] = {}
-		end
+    for k,v in pairs(ledNames or {}) do
+      gauge.leds[v] = {}
+    end
 
-		return gauge
-	end,
+    return gauge
+  end,
 
-	buildGui = function(self)
-		local els = self.guiElems
+  buildGui = function(self)
+    local els = self.guiElems
 
-		els.root = els.parent.add
-		{
-			type = "frame",
-			name = self.prefix .. "rootFrame",
-			style = "frame",
-			tooltip = {"heli-gui-gauges-tt"},
-		}
+    els.root = els.parent.add
+    {
+      type = "frame",
+      name = self.prefix .. "rootFrame",
+      style = "frame",
+      tooltip = {"heli-gui-gauges-tt"},
+    }
 
-		els.gauge_fs = self:buildGauge(els.root, "gauge_fs", {"fuel", "speed"}, {"fuel"})
-		els.gauge_hr = self:buildGauge(els.root, "gauge_hr", {"height", "rpm"})
+    els.gauge_fs = self:buildGauge(els.root, "gauge_fs", {"fuel", "speed"}, {"fuel"})
+    els.gauge_hr = self:buildGauge(els.root, "gauge_hr", {"height", "rpm"})
 
-		els.gauge_hr.speakerButtonFlow = els.root.add
-		{
-			type = "flow",
-			name = self.prefix .. "speakerButtonFlow",
-			direction = "horizontal",
-			tooltip = {"heli-gui-gauges-tt"},
-		}
+    els.gauge_hr.speakerButtonFlow = els.root.add
+    {
+      type = "flow",
+      name = self.prefix .. "speakerButtonFlow",
+      direction = "horizontal",
+      tooltip = {"heli-gui-gauges-tt"},
+    }
 
-		self:setMuted(Entity.get_data(self.player, "gaugeGui_muted"))
+    self:setMuted(Entity.get_data(self.player, "gaugeGui_muted"))
 
-		self:setGauge("gauge_fs", "fuel", self.pointerData.fuel.min)
-		self:setGauge("gauge_fs", "speed", self.pointerData.speed.min)
-		self:setGauge("gauge_hr", "height", self.pointerData.height.min)
-		self:setGauge("gauge_hr", "rpm", self.pointerData.rpm.min)
-	end,
+    self:setGauge("gauge_fs", "fuel", self.pointerData.fuel.min)
+    self:setGauge("gauge_fs", "speed", self.pointerData.speed.min)
+    self:setGauge("gauge_hr", "height", self.pointerData.height.min)
+    self:setGauge("gauge_hr", "rpm", self.pointerData.rpm.min)
+  end,
 }
 
 mtMgr.assign("gaugeGui", {__index = gaugeGui})

--- a/logic/gui/heliPadSelectionGui.lua
+++ b/logic/gui/heliPadSelectionGui.lua
@@ -2,221 +2,221 @@ mod_gui = require("mod-gui")
 
 heliPadSelectionGui = 
 {
-	prefix = "heli_heliPadSelectionGui_",
+  prefix = "heli_heliPadSelectionGui_",
 
-	new = function(mgr, p)
-		obj = 
-		{
-			valid = true,
-			manager = mgr,
-			player = p,
+  new = function(mgr, p)
+    obj = 
+    {
+      valid = true,
+      manager = mgr,
+      player = p,
 
-			guiElems = 
-			{
-				parent = mod_gui.get_frame_flow(p),
-			},
-			prefix = "heli_heliPadSelectionGui_",
-		}
+      guiElems = 
+      {
+        parent = mod_gui.get_frame_flow(p),
+      },
+      prefix = "heli_heliPadSelectionGui_",
+    }
 
-		setmetatable(obj, {__index = heliPadSelectionGui})
-		obj:buildGui()
+    setmetatable(obj, {__index = heliPadSelectionGui})
+    obj:buildGui()
 
-		return obj
-	end,
+    return obj
+  end,
 
-	destroy = function(self)
-		self.valid = false
-	
-		if self.guiElems.root and self.guiElems.root.valid then
-			self.guiElems.root.destroy()
-		end
-	end,
+  destroy = function(self)
+    self.valid = false
+  
+    if self.guiElems.root and self.guiElems.root.valid then
+      self.guiElems.root.destroy()
+    end
+  end,
 
-	OnGuiClick = function(self, e)
-		local name = e.element.name
+  OnGuiClick = function(self, e)
+    local name = e.element.name
 
-		if name:match("^" .. self.prefix .. "cam_%d+$") then
-			self:OnCamClicked(e)
+    if name:match("^" .. self.prefix .. "cam_%d+$") then
+      self:OnCamClicked(e)
 
-		elseif name == self.prefix .. "rootFrame" and e.button == defines.mouse_button_type.right then
-			self.manager:OnChildEvent(self, "cancel")
-		end
-	end,
+    elseif name == self.prefix .. "rootFrame" and e.button == defines.mouse_button_type.right then
+      self.manager:OnChildEvent(self, "cancel")
+    end
+  end,
 
-	OnCamClicked = function(self, e)
+  OnCamClicked = function(self, e)
 
-		if e.button == defines.mouse_button_type.left then
-			local camID = tonumber(e.element.name:match("%d+"))
-			local cam = searchInTable(self.guiElems.cams, camID, "ID")
-			self.manager:OnChildEvent(self, "selectedPosition", cam.heliPad.baseEnt.position)
+    if e.button == defines.mouse_button_type.left then
+      local camID = tonumber(e.element.name:match("%d+"))
+      local cam = searchInTable(self.guiElems.cams, camID, "ID")
+      self.manager:OnChildEvent(self, "selectedPosition", cam.heliPad.baseEnt.position)
 
-		elseif e.button == defines.mouse_button_type.right then
-			local zoomMax = 1.0125
-			local zoomMin = 0.025
-			local zoomDelta = 0.5
+    elseif e.button == defines.mouse_button_type.right then
+      local zoomMax = 1.0125
+      local zoomMin = 0.025
+      local zoomDelta = 0.5
 
-			if e.shift then
-				e.element.zoom = e.element.zoom * (1 + zoomDelta)
-				if e.element.zoom > zoomMax then
-					e.element.zoom = zoomMin
-				end
-			else
-				e.element.zoom = e.element.zoom * (1 - zoomDelta)
-				if e.element.zoom < zoomMin then
-					e.element.zoom = zoomMax
-				end
-			end
-		end
-	end,
+      if e.shift then
+        e.element.zoom = e.element.zoom * (1 + zoomDelta)
+        if e.element.zoom > zoomMax then
+          e.element.zoom = zoomMin
+        end
+      else
+        e.element.zoom = e.element.zoom * (1 - zoomDelta)
+        if e.element.zoom < zoomMin then
+          e.element.zoom = zoomMax
+        end
+      end
+    end
+  end,
 
-	OnHeliPadBuilt = function(self, heliPad)
-		if heliPad.baseEnt.force == self.player.force then
-			table.insert(self.guiElems.cams, 
-			{
-				cam = self:buildCam(self.guiElems.camTable, self.curCamID, heliPad.baseEnt.position, self:getDefaultZoom()),
-				ID = self.curCamID,
-				heliPad = heliPad,
-			})
-			self.curCamID = self.curCamID + 1
-			self:setNothingAvailable(false)
-		end
-	end,
+  OnHeliPadBuilt = function(self, heliPad)
+    if heliPad.baseEnt.force == self.player.force then
+      table.insert(self.guiElems.cams, 
+      {
+        cam = self:buildCam(self.guiElems.camTable, self.curCamID, heliPad.baseEnt.position, self:getDefaultZoom()),
+        ID = self.curCamID,
+        heliPad = heliPad,
+      })
+      self.curCamID = self.curCamID + 1
+      self:setNothingAvailable(false)
+    end
+  end,
 
-	OnHeliPadRemoved = function(self, heliPad)
-		local i = searchIndexInTable(self.guiElems.cams, heliPad, "heliPad")
-		if i then
-			self.guiElems.cams[i].cam.destroy()
-			table.remove(self.guiElems.cams, i)
+  OnHeliPadRemoved = function(self, heliPad)
+    local i = searchIndexInTable(self.guiElems.cams, heliPad, "heliPad")
+    if i then
+      self.guiElems.cams[i].cam.destroy()
+      table.remove(self.guiElems.cams, i)
 
-			if #self.guiElems.cams == 0 then
-				self:setNothingAvailable(true)
-			end
-		end
-	end,
+      if #self.guiElems.cams == 0 then
+        self:setNothingAvailable(true)
+      end
+    end
+  end,
 
-	OnPlayerChangedForce = function(self, player)
-		if player == self.player then
-			self.guiElems.root.destroy()
-			self.guiElems = {parent = self.guiElems.parent}
-			self:buildGui()
-		end
-	end,
+  OnPlayerChangedForce = function(self, player)
+    if player == self.player then
+      self.guiElems.root.destroy()
+      self.guiElems = {parent = self.guiElems.parent}
+      self:buildGui()
+    end
+  end,
 
-	getDefaultZoom = function(self)
-		return self.player.mod_settings["heli-gui-heliPadSelection-defaultZoom"].value
-	end,
+  getDefaultZoom = function(self)
+    return self.player.mod_settings["heli-gui-heliPadSelection-defaultZoom"].value
+  end,
 
-	buildCam = function(self, parent, ID, position, zoom)
-		local padding = 8
-		local size = 210
-		local camSize = size - padding
+  buildCam = function(self, parent, ID, position, zoom)
+    local padding = 8
+    local size = 210
+    local camSize = size - padding
 
-		local cam = parent.add
-		{
-			type = "camera",
-			name = self.prefix .. "cam_" .. tostring(ID),
-			position = position,
-			zoom = zoom,
-			tooltip = {"heli-gui-cam-tt"},
-		}
-		cam.style.top_padding = padding
-		cam.style.left_padding = padding
+    local cam = parent.add
+    {
+      type = "camera",
+      name = self.prefix .. "cam_" .. tostring(ID),
+      position = position,
+      zoom = zoom,
+      tooltip = {"heli-gui-cam-tt"},
+    }
+    cam.style.top_padding = padding
+    cam.style.left_padding = padding
 
-		cam.style.minimal_width = camSize
-		cam.style.minimal_height = camSize
+    cam.style.minimal_width = camSize
+    cam.style.minimal_height = camSize
 
-		--[[
-		if hasController then
-			local label = cam.add
-			{
-				type = "label",
-				caption = "  CONTROLLED",
-			}
+    --[[
+    if hasController then
+      local label = cam.add
+      {
+        type = "label",
+        caption = "  CONTROLLED",
+      }
 
-			label.style.font = "pixelated"
-			label.style.font_color = {r = 1, g = 0, b = 0}
-		end
-		]]
+      label.style.font = "pixelated"
+      label.style.font_color = {r = 1, g = 0, b = 0}
+    end
+    ]]
 
-		return cam
-	end,
+    return cam
+  end,
 
-	setNothingAvailable = function(self, val)
-		local els = self.guiElems
+  setNothingAvailable = function(self, val)
+    local els = self.guiElems
 
-		if val and not els.nothingAvailable then
-			els.nothingAvailable = els.camTable.add
-			{
-				type = "label",
-				name = self.prefix .. "nothingAvailable",
-				caption = {"heli-gui-padSelection-noPadsAvailable"},
-			}
-			els.nothingAvailable.style.font = "default-bold"
-			els.nothingAvailable.style.font_color = {r = 1, g = 0, b = 0}
+    if val and not els.nothingAvailable then
+      els.nothingAvailable = els.camTable.add
+      {
+        type = "label",
+        name = self.prefix .. "nothingAvailable",
+        caption = {"heli-gui-padSelection-noPadsAvailable"},
+      }
+      els.nothingAvailable.style.font = "default-bold"
+      els.nothingAvailable.style.font_color = {r = 1, g = 0, b = 0}
 
-		elseif not val and els.nothingAvailable then
-			els.nothingAvailable.destroy()
-			els.nothingAvailable = nil
-		end
-	end,
+    elseif not val and els.nothingAvailable then
+      els.nothingAvailable.destroy()
+      els.nothingAvailable = nil
+    end
+  end,
 
-	buildGui = function(self)
-		local els = self.guiElems
+  buildGui = function(self)
+    local els = self.guiElems
 
-		els.root = els.parent.add
-		{
-			type = "frame",
-			name = self.prefix .. "rootFrame",
-			caption = {"heli-gui-padSelection-frame-caption"},
-			style = "frame",
-			direction = "vertical",
-			tooltip = {"heli-gui-frame-tt"},
-		}
+    els.root = els.parent.add
+    {
+      type = "frame",
+      name = self.prefix .. "rootFrame",
+      caption = {"heli-gui-padSelection-frame-caption"},
+      style = "frame",
+      direction = "vertical",
+      tooltip = {"heli-gui-frame-tt"},
+    }
 
-		els.root.style.maximal_width = 1000
-		els.root.style.maximal_height = 700
+    els.root.style.maximal_width = 1000
+    els.root.style.maximal_height = 700
 
 
-			els.scrollPane = els.root.add
-			{
-				type = "scroll-pane",
-				name = self.prefix .. "scroller",
-			}
+      els.scrollPane = els.root.add
+      {
+        type = "scroll-pane",
+        name = self.prefix .. "scroller",
+      }
 
-			els.scrollPane.style.maximal_width = 1000
-			els.scrollPane.style.maximal_height = 600
+      els.scrollPane.style.maximal_width = 1000
+      els.scrollPane.style.maximal_height = 600
 
-				els.camTable = els.scrollPane.add
-				{
-					type = "table",
-					name = self.prefix .. "camTable",
-					column_count = 4,
-				}
-				els.camTable.style.horizontal_spacing = 10
-				els.camTable.style.vertical_spacing = 10
+        els.camTable = els.scrollPane.add
+        {
+          type = "table",
+          name = self.prefix .. "camTable",
+          column_count = 4,
+        }
+        els.camTable.style.horizontal_spacing = 10
+        els.camTable.style.vertical_spacing = 10
 
-					self.curCamID = 0
-					els.cams = {}
+          self.curCamID = 0
+          els.cams = {}
 
-					local hasCams = false
-					if global.heliPads then
-						for k, curPad in pairs(global.heliPads) do
-							if curPad.baseEnt.force == self.player.force then
-								hasCams = true
-								table.insert(els.cams, 
-								{
-									cam = self:buildCam(els.camTable, self.curCamID, curPad.baseEnt.position, self:getDefaultZoom()),
-									ID = self.curCamID,
-									heliPad = curPad,
-								})
+          local hasCams = false
+          if global.heliPads then
+            for k, curPad in pairs(global.heliPads) do
+              if curPad.baseEnt.force == self.player.force then
+                hasCams = true
+                table.insert(els.cams, 
+                {
+                  cam = self:buildCam(els.camTable, self.curCamID, curPad.baseEnt.position, self:getDefaultZoom()),
+                  ID = self.curCamID,
+                  heliPad = curPad,
+                })
 
-								self.curCamID = self.curCamID + 1
-							end
-						end
-					end
+                self.curCamID = self.curCamID + 1
+              end
+            end
+          end
 
-					if not hasCams then
-						self:setNothingAvailable(true)
-					end
-	end,
+          if not hasCams then
+            self:setNothingAvailable(true)
+          end
+  end,
 }

--- a/logic/gui/heliSelectionGui.lua
+++ b/logic/gui/heliSelectionGui.lua
@@ -2,417 +2,417 @@ mod_gui = require("mod-gui")
 
 heliSelectionGui =
 {
-	prefix = "heli_heliSelectionGui_",
-
-	new = function(mgr, p)
-		obj = 
-		{
-			valid = true,
-			manager = mgr,
-			player = p,
-
-			guiElems = 
-			{
-				parent = mod_gui.get_frame_flow(p),
-			},
-			prefix = "heli_heliSelectionGui_",
-
-			curCamID = 0,
-		}
-
-		setmetatable(obj, {__index = heliSelectionGui})
-
-		obj:buildGui()
-
-		return obj
-	end,
-
-	destroy = function(self)
-		self.valid = false
-	
-		if self.guiElems.root and self.guiElems.root.valid then
-			self.guiElems.root.destroy()
-		end
-	end,
-
-	setVisible = function(self, val)
-		self.guiElems.root.visible = val
-	end,
-
-	OnTick = function(self)
-		self:updateCamPositions()
-	end,
-
-	OnPlayerChangedForce = function(self, player)
-		if player == self.player then
-			local vis = self.visible
-			self.guiElems.root.destroy()
-			self.guiElems = {parent = self.guiElems.parent}
-			self.selectedCam = nil
-			self:buildGui()
-			self:setVisible(vis)
-		end
-	end,
-
-	OnGuiClick = function(self, e)
-		local name = e.element.name
-
-		if name:match("^" .. self.prefix .. "cam_%d+$") then
-			self:OnCamClicked(e)
-
-		elseif name == self.prefix .. "rootFrame" and e.button == defines.mouse_button_type.right then
-			self.manager:OnChildEvent(self, "cancel")
-
-		elseif self.selectedCam then
-			if name == self.prefix .. "btn_toPlayer" then
-				if e.button == defines.mouse_button_type.left then
-					if e.shift then
-						self.manager:OnChildEvent(self, "selectedPosition", self.player.position)
-					else
-						self.manager:OnChildEvent(self, "selectedPlayer", self.player)
-					end
-				else
-					self.manager:OnChildEvent(self, "showTargetSelectionGui", playerSelectionGui)
-				end
-
-			elseif name == self.prefix .. "btn_toMap" then
-				self.manager:OnChildEvent(self, "showTargetSelectionGui", markerSelectionGui)
-
-			elseif name == self.prefix .. "btn_toPad" then
-				self.manager:OnChildEvent(self, "showTargetSelectionGui", heliPadSelectionGui)
-
-			elseif name == self.prefix .. "btn_stop" then
-				if self.selectedCam.heliController then
-					self.selectedCam.heliController:stopAndDestroy()
-				end
-			end
-		end
-	end,
-
-	OnHeliBuilt = function(self, heli)
-		if heli.baseEnt.force == self.player.force then
-			local flow, cam = self:buildCam(self.guiElems.camTable, self.curCamID, heli.baseEnt.position, 0.3, false, false)
-
-			table.insert(self.guiElems.cams,
-			{
-				flow = flow,
-				cam = cam,
-				heli = heli,
-				ID = self.curCamID,
-			})
-
-			self.curCamID = self.curCamID + 1
-
-			self:setNothingAvailableIfNecessary()
-		end
-	end,
-
-	OnHeliRemoved = function(self, heli)
-		for i, curCam in ipairs(self.guiElems.cams) do
-			if curCam.heli == heli then
-				if curCam == self.selectedCam then
-					self.selectedCam = nil
-					self:setControlBtnsStatus(false, false)
-					self.manager:OnChildEvent(self, "OnSelectedHeliIsInvalid")
-				end
-
-				curCam.flow.destroy()
-				table.remove(self.guiElems.cams, i)
-				self:setNothingAvailableIfNecessary()
-				break
-			end
-		end
-	end,
-
-	OnHeliControllerCreated = function(self, controller)
-		local cam = searchInTable(self.guiElems.cams, controller.heli, "heli")
-		if cam then
-			cam.heliController = controller
-			self:setCamStatus(cam, cam == self.selectedCam, true)
-		end
-	end,
-
-	OnHeliControllerDestroyed = function(self, controller)
-		local cam = searchInTable(self.guiElems.cams, controller, "heliController")
-		if cam then
-			cam.heliController = nil
-			self:setCamStatus(cam, cam == self.selectedCam, false)
-		end
-	end,
-
-	OnCamClicked = function(self, e)
-		if e.button == defines.mouse_button_type.left then
-			local camID = tonumber(e.element.name:match("%d+"))
-			local cam = searchInTable(self.guiElems.cams, camID, "ID")
-			self:setCamStatus(cam, true, cam.heliController)
-
-			Entity.set_data(self.player, cam.heli, "heliSelectionGui_lastSelectedHeli")
-
-		elseif e.button == defines.mouse_button_type.right then
-			local zoomMax = 1.26
-			local zoomMin = 0.2
-			local zoomDelta = 0.333
-
-			if e.shift then
-				e.element.zoom = e.element.zoom * (1 + zoomDelta)
-				if e.element.zoom > zoomMax then
-					e.element.zoom = zoomMin
-				end
-			else
-				e.element.zoom = e.element.zoom * (1 - zoomDelta)
-				if e.element.zoom < zoomMin then
-					e.element.zoom = zoomMax
-				end
-			end
-		end
-	end,
-
-	getDefaultZoom = function(self)
-		return self.player.mod_settings["heli-gui-heliSelection-defaultZoom"].value
-	end,
-
-	getCamIndexById = function(self, ID)
-		for i, curCam in ipairs(self.guiElems.cams) do
-			if curCam.ID == ID then return i end
-		end
-	end,
-
-	updateCamPositions = function(self)
-		for k, curCam in pairs(self.guiElems.cams) do
-			if curCam.heli.valid then
-				curCam.cam.position = curCam.heli.baseEnt.position
-			end
-		end
-	end,
-
-	setCamStatus = function(self, cam, isSelected, hasController)
-		local flow = cam.flow
-
-		local pos = cam.cam.position
-		local zoom = cam.cam.zoom
-
-		flow.clear()
-
-		cam.cam = self:buildCamInner(flow, cam.ID, pos, zoom, isSelected, cam.heliController)
-
-		if isSelected then
-			if self.selectedCam and self.selectedCam ~= cam then
-				self:setCamStatus(self.selectedCam, false, hasController)
-			end
-			self.selectedCam = cam
-			self:setControlBtnsStatus(isSelected, hasController)
-		else
-			if self.selectedCam and self.selectedCam == cam then
-				self.selectedCam = nil
-			end
-		end
-	end,
-
-	setControlBtnsStatus = function(self, heliSelected, hasController)
-		self.guiElems.btnToPlayer.enabled = heliSelected
-		self.guiElems.btnToMap.enabled = heliSelected
-		self.guiElems.btnToPad.enabled = heliSelected
-		self.guiElems.btnStop.enabled = heliSelected and hasController
-	end,
-
-	setNothingAvailableIfNecessary = function(self)
-		local els = self.guiElems
-		local nec = #els.cams == 0
-
-		if nec and not els.nothingAvailable then
-			els.nothingAvailable = els.camTable.add
-			{
-				type = "label",
-				name = self.prefix .. "nothingAvailable",
-				caption = {"heli-gui-heliSelection-noHelisAvailable"},
-			}
-			els.nothingAvailable.style.font = "default-bold"
-			els.nothingAvailable.style.font_color = {r = 1, g = 0, b = 0}
-
-		elseif not nec and els.nothingAvailable then
-			els.nothingAvailable.destroy()
-			els.nothingAvailable = nil
-		end
-	end,
-
-	buildCamInner = function(self, parent, ID, position, zoom, isSelected, hasController)
-		local camParent = parent
-		local padding = 8
-		local size = 210
-		local camSize = size - padding
-
-		if isSelected then
-			camParent = camParent.add
-			{
-				type = "sprite",
-				name = self.prefix .. "camBox_selected_" .. tostring(ID),
-				sprite = "heli_gui_selected",
-			}
-			camParent.style.minimal_width = size
-			camParent.style.minimal_height = size
-			camParent.style.maximal_width = size
-			camParent.style.maximal_height = size
-		end
-
-		local cam = camParent.add
-		{
-			type = "camera",
-			name = self.prefix .. "cam_" .. tostring(ID),
-			position = position,
-			zoom = zoom,
-			tooltip = {"heli-gui-cam-tt"},
-		}
-		cam.style.top_padding = padding
-		cam.style.left_padding = padding
-
-		cam.style.minimal_width = camSize
-		cam.style.minimal_height = camSize
-
-		if hasController then
-			local label = cam.add
-			{
-				type = "label",
-				caption = {"heli-gui-heliSelection-controlled"},
-			}
-
-			label.style.font = "pixelated"
-			label.style.font_color = {r = 1, g = 0, b = 0}
-		end
-
-		return cam
-	end,
-
-	buildCam = function(self, parent, ID, position, zoom, isSelected, hasController)
-		local flow = parent.add
-		{
-			type = "flow",
-			name = self.prefix .. "camFlow_" .. tostring(ID),
-		}
-
-		flow.style.minimal_width = 214
-		flow.style.minimal_height = 214
-		flow.style.maximal_width = 214
-		flow.style.maximal_height = 214
-
-		return flow, self:buildCamInner(flow, ID, position, zoom, isSelected, hasController)
-	end,
-
-	buildGui = function(self, selectedIndex)
-		local p = self.player
-		local els = self.guiElems
-
-		els.root = els.parent.add
-		{
-			type = "frame",
-			name = self.prefix .. "rootFrame",
-			caption = {"heli-gui-heliSelection-frame-caption"},
-			style = "frame",
-			direction = "vertical",
-			tooltip = {"heli-gui-frame-tt"},
-		}
-
-		els.root.style.maximal_width = 1000
-		els.root.style.maximal_height = 700
-
-			els.buttonFlow = els.root.add
-			{
-				type = "flow",
-				name = self.prefix .. "btnFlow",
-			}
-			els.buttonFlow.style.left_padding = 7
-
-				els.btnToPlayer = els.buttonFlow.add
-				{
-					type = "sprite-button",
-					name = self.prefix .. "btn_toPlayer",
-					sprite = "heli_to_player",
-					style = mod_gui.button_style,
-					tooltip = {"heli-gui-heliSelection-to-player-btn-tt"},
-				}
-
-				els.btnToMap = els.buttonFlow.add
-				{
-					type = "sprite-button",
-					name = self.prefix .. "btn_toMap",
-					sprite = "heli_to_map",
-					style = mod_gui.button_style,
-				}
-
-				els.btnToPad = els.buttonFlow.add
-				{
-					type = "sprite-button",
-					name = self.prefix .. "btn_toPad",
-					sprite = "heli_to_pad",
-					style = mod_gui.button_style,
-				}
-
-				els.btnStop = els.buttonFlow.add
-				{
-					type = "sprite-button",
-					name = self.prefix .. "btn_stop",
-					sprite = "heli_stop",
-					style = mod_gui.button_style,
-				}
-				self:setControlBtnsStatus(false, false)
-
-			els.scrollPane = els.root.add
-			{
-				type = "scroll-pane",
-				name = self.prefix .. "scroller",
-			}
-
-			els.scrollPane.style.maximal_width = 1000
-			els.scrollPane.style.maximal_height = 600
-
-				els.camTable = els.scrollPane.add
-				{
-					type = "table",
-					name = self.prefix .. "camTable",
-					column_count = 4,
-				}
-				els.camTable.style.horizontal_spacing = 10
-				els.camTable.style.vertical_spacing = 10
-
-					els.cams ={}
-					self.curCamID = 0
-
-					if global.helis then
-						local lastSelected = Entity.get_data(self.player, "heliSelectionGui_lastSelectedHeli")
-						local selectedSomething = false
-
-						for k, curHeli in pairs(global.helis) do
-							local curDriver = curHeli.baseEnt.get_driver()
-							
-							if curHeli.baseEnt.force == self.player.force and 
-								(curDriver == nil or curHeli.hasRemoteController or
-									(curDriver.player and curDriver.player.valid and curDriver.player.name == self.player.name)) then
-
-								local controller = searchInTable(global.heliControllers, curHeli, "heli")
-								local flow, cam = self:buildCam(els.camTable, self.curCamID, curHeli.baseEnt.position, self:getDefaultZoom(), selected, curHeli.hasRemoteController)
-
-								table.insert(els.cams,
-								{
-									flow = flow,
-									cam = cam,
-									heli = curHeli,
-									heliController = controller,
-									ID = self.curCamID,
-								})
-
-								self.curCamID = self.curCamID + 1
-								
-								if curHeli == lastSelected then
-									selectedSomething = true
-									self:setCamStatus(els.cams[self.curCamID], true, heliController)	
-								end						
-							end
-						end
-
-						if not selectedSomething and #els.cams > 0 then
-							self:setCamStatus(els.cams[1], true, els.cams[1].heliController)
-						end
-					end
-
-					self:setNothingAvailableIfNecessary()
-	end,
+  prefix = "heli_heliSelectionGui_",
+
+  new = function(mgr, p)
+    obj = 
+    {
+      valid = true,
+      manager = mgr,
+      player = p,
+
+      guiElems = 
+      {
+        parent = mod_gui.get_frame_flow(p),
+      },
+      prefix = "heli_heliSelectionGui_",
+
+      curCamID = 0,
+    }
+
+    setmetatable(obj, {__index = heliSelectionGui})
+
+    obj:buildGui()
+
+    return obj
+  end,
+
+  destroy = function(self)
+    self.valid = false
+  
+    if self.guiElems.root and self.guiElems.root.valid then
+      self.guiElems.root.destroy()
+    end
+  end,
+
+  setVisible = function(self, val)
+    self.guiElems.root.visible = val
+  end,
+
+  OnTick = function(self)
+    self:updateCamPositions()
+  end,
+
+  OnPlayerChangedForce = function(self, player)
+    if player == self.player then
+      local vis = self.visible
+      self.guiElems.root.destroy()
+      self.guiElems = {parent = self.guiElems.parent}
+      self.selectedCam = nil
+      self:buildGui()
+      self:setVisible(vis)
+    end
+  end,
+
+  OnGuiClick = function(self, e)
+    local name = e.element.name
+
+    if name:match("^" .. self.prefix .. "cam_%d+$") then
+      self:OnCamClicked(e)
+
+    elseif name == self.prefix .. "rootFrame" and e.button == defines.mouse_button_type.right then
+      self.manager:OnChildEvent(self, "cancel")
+
+    elseif self.selectedCam then
+      if name == self.prefix .. "btn_toPlayer" then
+        if e.button == defines.mouse_button_type.left then
+          if e.shift then
+            self.manager:OnChildEvent(self, "selectedPosition", self.player.position)
+          else
+            self.manager:OnChildEvent(self, "selectedPlayer", self.player)
+          end
+        else
+          self.manager:OnChildEvent(self, "showTargetSelectionGui", playerSelectionGui)
+        end
+
+      elseif name == self.prefix .. "btn_toMap" then
+        self.manager:OnChildEvent(self, "showTargetSelectionGui", markerSelectionGui)
+
+      elseif name == self.prefix .. "btn_toPad" then
+        self.manager:OnChildEvent(self, "showTargetSelectionGui", heliPadSelectionGui)
+
+      elseif name == self.prefix .. "btn_stop" then
+        if self.selectedCam.heliController then
+          self.selectedCam.heliController:stopAndDestroy()
+        end
+      end
+    end
+  end,
+
+  OnHeliBuilt = function(self, heli)
+    if heli.baseEnt.force == self.player.force then
+      local flow, cam = self:buildCam(self.guiElems.camTable, self.curCamID, heli.baseEnt.position, 0.3, false, false)
+
+      table.insert(self.guiElems.cams,
+      {
+        flow = flow,
+        cam = cam,
+        heli = heli,
+        ID = self.curCamID,
+      })
+
+      self.curCamID = self.curCamID + 1
+
+      self:setNothingAvailableIfNecessary()
+    end
+  end,
+
+  OnHeliRemoved = function(self, heli)
+    for i, curCam in ipairs(self.guiElems.cams) do
+      if curCam.heli == heli then
+        if curCam == self.selectedCam then
+          self.selectedCam = nil
+          self:setControlBtnsStatus(false, false)
+          self.manager:OnChildEvent(self, "OnSelectedHeliIsInvalid")
+        end
+
+        curCam.flow.destroy()
+        table.remove(self.guiElems.cams, i)
+        self:setNothingAvailableIfNecessary()
+        break
+      end
+    end
+  end,
+
+  OnHeliControllerCreated = function(self, controller)
+    local cam = searchInTable(self.guiElems.cams, controller.heli, "heli")
+    if cam then
+      cam.heliController = controller
+      self:setCamStatus(cam, cam == self.selectedCam, true)
+    end
+  end,
+
+  OnHeliControllerDestroyed = function(self, controller)
+    local cam = searchInTable(self.guiElems.cams, controller, "heliController")
+    if cam then
+      cam.heliController = nil
+      self:setCamStatus(cam, cam == self.selectedCam, false)
+    end
+  end,
+
+  OnCamClicked = function(self, e)
+    if e.button == defines.mouse_button_type.left then
+      local camID = tonumber(e.element.name:match("%d+"))
+      local cam = searchInTable(self.guiElems.cams, camID, "ID")
+      self:setCamStatus(cam, true, cam.heliController)
+
+      Entity.set_data(self.player, cam.heli, "heliSelectionGui_lastSelectedHeli")
+
+    elseif e.button == defines.mouse_button_type.right then
+      local zoomMax = 1.26
+      local zoomMin = 0.2
+      local zoomDelta = 0.333
+
+      if e.shift then
+        e.element.zoom = e.element.zoom * (1 + zoomDelta)
+        if e.element.zoom > zoomMax then
+          e.element.zoom = zoomMin
+        end
+      else
+        e.element.zoom = e.element.zoom * (1 - zoomDelta)
+        if e.element.zoom < zoomMin then
+          e.element.zoom = zoomMax
+        end
+      end
+    end
+  end,
+
+  getDefaultZoom = function(self)
+    return self.player.mod_settings["heli-gui-heliSelection-defaultZoom"].value
+  end,
+
+  getCamIndexById = function(self, ID)
+    for i, curCam in ipairs(self.guiElems.cams) do
+      if curCam.ID == ID then return i end
+    end
+  end,
+
+  updateCamPositions = function(self)
+    for k, curCam in pairs(self.guiElems.cams) do
+      if curCam.heli.valid then
+        curCam.cam.position = curCam.heli.baseEnt.position
+      end
+    end
+  end,
+
+  setCamStatus = function(self, cam, isSelected, hasController)
+    local flow = cam.flow
+
+    local pos = cam.cam.position
+    local zoom = cam.cam.zoom
+
+    flow.clear()
+
+    cam.cam = self:buildCamInner(flow, cam.ID, pos, zoom, isSelected, cam.heliController)
+
+    if isSelected then
+      if self.selectedCam and self.selectedCam ~= cam then
+        self:setCamStatus(self.selectedCam, false, hasController)
+      end
+      self.selectedCam = cam
+      self:setControlBtnsStatus(isSelected, hasController)
+    else
+      if self.selectedCam and self.selectedCam == cam then
+        self.selectedCam = nil
+      end
+    end
+  end,
+
+  setControlBtnsStatus = function(self, heliSelected, hasController)
+    self.guiElems.btnToPlayer.enabled = heliSelected
+    self.guiElems.btnToMap.enabled = heliSelected
+    self.guiElems.btnToPad.enabled = heliSelected
+    self.guiElems.btnStop.enabled = heliSelected and hasController
+  end,
+
+  setNothingAvailableIfNecessary = function(self)
+    local els = self.guiElems
+    local nec = #els.cams == 0
+
+    if nec and not els.nothingAvailable then
+      els.nothingAvailable = els.camTable.add
+      {
+        type = "label",
+        name = self.prefix .. "nothingAvailable",
+        caption = {"heli-gui-heliSelection-noHelisAvailable"},
+      }
+      els.nothingAvailable.style.font = "default-bold"
+      els.nothingAvailable.style.font_color = {r = 1, g = 0, b = 0}
+
+    elseif not nec and els.nothingAvailable then
+      els.nothingAvailable.destroy()
+      els.nothingAvailable = nil
+    end
+  end,
+
+  buildCamInner = function(self, parent, ID, position, zoom, isSelected, hasController)
+    local camParent = parent
+    local padding = 8
+    local size = 210
+    local camSize = size - padding
+
+    if isSelected then
+      camParent = camParent.add
+      {
+        type = "sprite",
+        name = self.prefix .. "camBox_selected_" .. tostring(ID),
+        sprite = "heli_gui_selected",
+      }
+      camParent.style.minimal_width = size
+      camParent.style.minimal_height = size
+      camParent.style.maximal_width = size
+      camParent.style.maximal_height = size
+    end
+
+    local cam = camParent.add
+    {
+      type = "camera",
+      name = self.prefix .. "cam_" .. tostring(ID),
+      position = position,
+      zoom = zoom,
+      tooltip = {"heli-gui-cam-tt"},
+    }
+    cam.style.top_padding = padding
+    cam.style.left_padding = padding
+
+    cam.style.minimal_width = camSize
+    cam.style.minimal_height = camSize
+
+    if hasController then
+      local label = cam.add
+      {
+        type = "label",
+        caption = {"heli-gui-heliSelection-controlled"},
+      }
+
+      label.style.font = "pixelated"
+      label.style.font_color = {r = 1, g = 0, b = 0}
+    end
+
+    return cam
+  end,
+
+  buildCam = function(self, parent, ID, position, zoom, isSelected, hasController)
+    local flow = parent.add
+    {
+      type = "flow",
+      name = self.prefix .. "camFlow_" .. tostring(ID),
+    }
+
+    flow.style.minimal_width = 214
+    flow.style.minimal_height = 214
+    flow.style.maximal_width = 214
+    flow.style.maximal_height = 214
+
+    return flow, self:buildCamInner(flow, ID, position, zoom, isSelected, hasController)
+  end,
+
+  buildGui = function(self, selectedIndex)
+    local p = self.player
+    local els = self.guiElems
+
+    els.root = els.parent.add
+    {
+      type = "frame",
+      name = self.prefix .. "rootFrame",
+      caption = {"heli-gui-heliSelection-frame-caption"},
+      style = "frame",
+      direction = "vertical",
+      tooltip = {"heli-gui-frame-tt"},
+    }
+
+    els.root.style.maximal_width = 1000
+    els.root.style.maximal_height = 700
+
+      els.buttonFlow = els.root.add
+      {
+        type = "flow",
+        name = self.prefix .. "btnFlow",
+      }
+      els.buttonFlow.style.left_padding = 7
+
+        els.btnToPlayer = els.buttonFlow.add
+        {
+          type = "sprite-button",
+          name = self.prefix .. "btn_toPlayer",
+          sprite = "heli_to_player",
+          style = mod_gui.button_style,
+          tooltip = {"heli-gui-heliSelection-to-player-btn-tt"},
+        }
+
+        els.btnToMap = els.buttonFlow.add
+        {
+          type = "sprite-button",
+          name = self.prefix .. "btn_toMap",
+          sprite = "heli_to_map",
+          style = mod_gui.button_style,
+        }
+
+        els.btnToPad = els.buttonFlow.add
+        {
+          type = "sprite-button",
+          name = self.prefix .. "btn_toPad",
+          sprite = "heli_to_pad",
+          style = mod_gui.button_style,
+        }
+
+        els.btnStop = els.buttonFlow.add
+        {
+          type = "sprite-button",
+          name = self.prefix .. "btn_stop",
+          sprite = "heli_stop",
+          style = mod_gui.button_style,
+        }
+        self:setControlBtnsStatus(false, false)
+
+      els.scrollPane = els.root.add
+      {
+        type = "scroll-pane",
+        name = self.prefix .. "scroller",
+      }
+
+      els.scrollPane.style.maximal_width = 1000
+      els.scrollPane.style.maximal_height = 600
+
+        els.camTable = els.scrollPane.add
+        {
+          type = "table",
+          name = self.prefix .. "camTable",
+          column_count = 4,
+        }
+        els.camTable.style.horizontal_spacing = 10
+        els.camTable.style.vertical_spacing = 10
+
+          els.cams ={}
+          self.curCamID = 0
+
+          if global.helis then
+            local lastSelected = Entity.get_data(self.player, "heliSelectionGui_lastSelectedHeli")
+            local selectedSomething = false
+
+            for k, curHeli in pairs(global.helis) do
+              local curDriver = curHeli.baseEnt.get_driver()
+              
+              if curHeli.baseEnt.force == self.player.force and 
+                (curDriver == nil or curHeli.hasRemoteController or
+                  (curDriver.player and curDriver.player.valid and curDriver.player.name == self.player.name)) then
+
+                local controller = searchInTable(global.heliControllers, curHeli, "heli")
+                local flow, cam = self:buildCam(els.camTable, self.curCamID, curHeli.baseEnt.position, self:getDefaultZoom(), selected, curHeli.hasRemoteController)
+
+                table.insert(els.cams,
+                {
+                  flow = flow,
+                  cam = cam,
+                  heli = curHeli,
+                  heliController = controller,
+                  ID = self.curCamID,
+                })
+
+                self.curCamID = self.curCamID + 1
+                
+                if curHeli == lastSelected then
+                  selectedSomething = true
+                  self:setCamStatus(els.cams[self.curCamID], true, heliController)  
+                end            
+              end
+            end
+
+            if not selectedSomething and #els.cams > 0 then
+              self:setCamStatus(els.cams[1], true, els.cams[1].heliController)
+            end
+          end
+
+          self:setNothingAvailableIfNecessary()
+  end,
 }

--- a/logic/gui/markerSelectionGui.lua
+++ b/logic/gui/markerSelectionGui.lua
@@ -2,356 +2,356 @@ mod_gui = require("mod-gui")
 
 markerSelectionGui =
 {
-	prefix = "heli_markerSelectionGui_",
-	refreshCooldown = 20,
-
-	new = function(mgr, p)
-		obj = 
-		{
-			valid = true,
-			manager = mgr,
-			player = p,
-
-			guiElems = 
-			{
-				parent = mod_gui.get_frame_flow(p),
-			},
-
-			curRefreshCooldown = markerSelectionGui.refreshCooldown,
-			prefix = "heli_markerSelectionGui_",
-		}
-
-		setmetatable(obj, {__index = markerSelectionGui})
-
-		obj:buildGui()
-
-		if p.mod_settings["heli-auto-focus-searchfields"].value then 
-			obj.guiElems.searchField.focus()
-		end
-
-		return obj
-	end,
-
-	destroy = function(self)
-		self.valid = false
-	
-		if self.guiElems.root and self.guiElems.root.valid then
-			self.guiElems.root.destroy()
-		end
-	end,
-
-	OnTick = function(self)
-		self.curRefreshCooldown = self.curRefreshCooldown - 1
-
-		if self.curRefreshCooldown == 0 then
-			self.curRefreshCooldown = self.refreshCooldown
-			self:refreshBtnList()
-		end
-	end,
-
-	OnPlayerChangedForce = function(self, player)
-		if player == self.player then
-			self.guiElems.root.destroy()
-			self.guiElems = {parent = self.guiElems.parent}
-			self:buildGui()
-		end
-	end,
-
-	OnGuiClick = function(self, e)
-		local name = e.element.name
-
-		if name:match("^" .. self.prefix .. "btn_%d+$") then
-			local ID = tonumber(e.element.name:match("%d+"))
-
-			for k, curBtn in pairs(self.guiElems.btns) do
-				if curBtn.tag.tag_number == ID then
-					if curBtn.tag.valid then
-						self.manager:OnChildEvent(self, "selectedPosition", curBtn.tag.position)
-					end
-					break
-				end
-			end
-
-		elseif name == self.prefix .. "rootFrame" and e.button == defines.mouse_button_type.right then
-			self.manager:OnChildEvent(self, "cancel")
-
-		elseif name == self.prefix .. "searchFieldClearBtn" then
-			self.guiElems.searchField.text = ""
-			self:OnGuiTextChanged({element = self.guiElems.searchField})
-		end
-	end,
-
-	OnGuiTextChanged = function(self, e)
-		local name = e.element.name
-		local newText = e.element.text
-
-		if name == self.prefix .. "searchField" then
-			if newText:contains(self.lastSearchFieldText) then
-				self:filterBtnList(newText)
-			else
-				self:buildBtnList()
-			end
-
-			self.lastSearchFieldText = newText
-		end
-	end,
-
-	removeBtnIndex = function(self, index)
-		self.guiElems.btns[index].btn.destroy()
-		table.remove(self.guiElems.btns, index)
-	end,
-
-	filterBtnList = function(self, filterStr)
-		for i = #self.guiElems.btns, 1, -1 do --iterate backwards so table.remove doesnt mess up the indices
-			local curBtn = self.guiElems.btns[i]
-			if not curBtn.text:contains(filterStr) then
-				self:removeBtnIndex(i)
-			end
-		end
-		self:setNothingAvailableIfNecessary()
-	end,
-
-	refreshBtnList = function(self)
-		local allTags = self:getFilteredChartTags()
-
-		local numNewTags = #allTags
-		local newTags = {}
-		for k,v in pairs(allTags) do
-			newTags[v.tag_number] = v
-		end
-
-		for i = #self.guiElems.btns, 1, -1 do --iterate backwards so table.remove doesnt mess up the indices
-			local curBtn = self.guiElems.btns[i]
-
-			if not curBtn.tag.valid then
-				self:removeBtnIndex(i)
-			
-			else
-				if newTags[curBtn.tag.tag_number] then
-					newTags[curBtn.tag.tag_number] = nil
-					numNewTags = numNewTags - 1
-				end
-
-				if curBtn.text ~= curBtn.tag.text then
-					curBtn.text = curBtn.tag.text
-					curBtn.btn.caption = "                " .. curBtn.tag.text
-				end
-
-				if not curBtn.icon and curBtn.tag.icon then
-					curBtn.icon, curBtn.iconType, curBtn.iconName = self:buildIconFromTag(curBtn.btn, curBtn.tag)
-				
-				elseif curBtn.icon and not curBtn.tag.icon then
-					curBtn.icon.destroy()
-					curBtn.icon, curBtn.iconType, curBtn.iconName = nil, nil, nil
-
-				elseif curBtn.icon and (curBtn.iconType ~= curBtn.tag.icon.type or curBtn.iconName ~= curBtn.tag.icon.name) then
-					curBtn.icon.destroy()
-					curBtn.icon, curBtn.iconType, curBtn.iconName = self:buildIconFromTag(curBtn.btn, curBtn.tag)
-				end
-			end
-		end
-
-		if numNewTags > 0 then
-			if #allTags > 666 then
-				for k, curTag in pairs(newTags) do
-					table.insert(self.guiElems.btns, self:buildBtnFromTag(self.guiElems.table, curTag))
-				end
-
-			else
-				self:buildBtnList(allTags)
-			end
-		end
-
-		self:setNothingAvailableIfNecessary()
-	end,
-
-	setNothingAvailableIfNecessary = function(self)
-		local els = self.guiElems
-		local listIsEmpty = #els.btns == 0
-
-		if listIsEmpty and not els.nothingAvailable then
-			els.nothingAvailable = els.scroller.add
-			{
-				type = "label",
-				name = self.prefix .. "nothingAvailable",
-				caption = "NO MAP MARKERS AVAILABLE",
-			}
-			els.nothingAvailable.style.font = "default-bold"
-			els.nothingAvailable.style.font_color = {r = 1, g = 0, b = 0}
-
-		elseif not listIsEmpty and els.nothingAvailable then
-			els.nothingAvailable.destroy()
-			els.nothingAvailable = nil
-		end
-	end,
-
-	getFilteredChartTags = function(self)
-		local tagList = self.player.force.find_chart_tags(self.player.surface)
-
-		for i = #tagList, 1, -1 do
-			if not tagList[i].text:contains(self.guiElems.searchField.text) then
-				table.remove(tagList, i)
-			end
-		end
-
-		return tagList
-	end,
-
-	buildIconFromTag = function(self, parent, tag)
-		local sprite
-		if tag.icon.type == "virtual" then
-			sprite = "virtual-signal" .. "/" .. tag.icon.name
-		else
-			sprite = tag.icon.type .. "/" .. tag.icon.name
-		end
-
-		local icon = parent.add
-		{
-			type = "sprite",
-			name = self.prefix .. "icon",
-			sprite = sprite,
-		}
-
-		return icon, tag.icon.type, tag.icon.name
-	end,
-
-	buildBtnFromTag = function(self, parent, tag)
-		local btn = parent.add
-		{
-			type = "button",
-			name = self.prefix .. "btn_" .. tostring(tag.tag_number),
-			style = "heli-listbox_button",
-			caption = "                " .. tag.text,
-		}
-		btn.style.minimal_height = 38
-		btn.style.minimal_width = 290
-
-		local icon, iconType, iconName = nil, nil, nil
-		if tag.icon then
-			icon, iconType, iconName = self:buildIconFromTag(btn, tag)
-		end
-
-		return {
-			btn = btn,
-			icon = icon,
-
-			tag = tag,
-			
-			text = tag.text,		
-			iconType = iconType,
-			iconName = iconName,
-		}
-	end,
-
-	buildBtnList = function(self, _tagList)
-		local tagList = _tagList or self:getFilteredChartTags()
-
-		table.sort(tagList, self.tagCompareCB)
-
-		self.guiElems.btns = {}
-		self.guiElems.table.clear()
-		for k, curTag in pairs(tagList) do
-			table.insert(self.guiElems.btns, self:buildBtnFromTag(self.guiElems.table, curTag))
-		end
-		
-		self:setNothingAvailableIfNecessary()
-	end,
-
-	tagCompareCB = function(a, b)
-		local aText = a.text ~= ""
-		local aIcon = a.icon
-
-		local bText = b.text ~= ""
-		local bIcon = b.icon
-
-		local sameText = a.text == b.text
-
-		if aText and bText then --both have text
-			if sameText then
-				return aIcon and not bIcon
-			end
-
-			return a.text < b.text
-
-		elseif aText then --only a has text
-			return true
-
-		elseif bText then --only b has text
-			return false
-
-		--neither has text
-
-		elseif aIcon and not bIcon then --only a has icon
-			return true
-		end
-
-		return false
-	end,
-
-	buildGui = function(self)
-		self.guiElems.root = self.guiElems.parent.add
-		{
-			type = "frame",
-			name = self.prefix .. "rootFrame",
-			caption = {"heli-gui-markerSelection-frame-caption"},
-			direction = "vertical",
-			style = "frame",
-			tooltip = {"heli-gui-frame-tt"},
-		}
-
-		self.guiElems.searchFieldFlow = self.guiElems.root.add
-		{
-			type = "flow",
-			name = self.prefix .. "searchFieldFlow",
-			direction = "horizontal",
-
-		}
-
-			self.guiElems.searchField = self.guiElems.searchFieldFlow.add
-			{
-				type = "textfield",
-				name = self.prefix .. "searchField",
-				style = "search_textfield_with_fixed_width",
-			}
-			self.guiElems.searchField.style.left_padding = 22
-			self.guiElems.searchField.style.minimal_height = 26
-			self.guiElems.searchField.style.maximal_height = 32
-
-			self.lastSearchFieldText = ""
-			
-				self.guiElems.searchField.add{
-					type = "sprite",
-					name = self.prefix .. "searchIcon",
-					sprite = "heli_search_icon",
-					--style = "heli_search_icon_style",
-				}
-
-
-			self.guiElems.searchFieldClearBtn = self.guiElems.searchFieldFlow.add
-			{
-				type = "button",
-				name = self.prefix .. "searchFieldClearBtn",
-				style = "heli-clear_text_button",
-			}
-		
-
-		self.guiElems.scroller = self.guiElems.root.add
-		{
-			type = "scroll-pane",
-			name = self.prefix .. "scroller",
-		}
-
-		self.guiElems.scroller.style.maximal_width = 1000
-		self.guiElems.scroller.style.maximal_height = 600
-
-		self.guiElems.table = self.guiElems.scroller.add
-		{
-			type = "flow",
-			name = self.prefix .. "flow",
-			style = "achievements_vertical_flow",
-			direction = "vertical",
-		}
-
-		self:buildBtnList()
-	end,
+  prefix = "heli_markerSelectionGui_",
+  refreshCooldown = 20,
+
+  new = function(mgr, p)
+    obj = 
+    {
+      valid = true,
+      manager = mgr,
+      player = p,
+
+      guiElems = 
+      {
+        parent = mod_gui.get_frame_flow(p),
+      },
+
+      curRefreshCooldown = markerSelectionGui.refreshCooldown,
+      prefix = "heli_markerSelectionGui_",
+    }
+
+    setmetatable(obj, {__index = markerSelectionGui})
+
+    obj:buildGui()
+
+    if p.mod_settings["heli-auto-focus-searchfields"].value then 
+      obj.guiElems.searchField.focus()
+    end
+
+    return obj
+  end,
+
+  destroy = function(self)
+    self.valid = false
+  
+    if self.guiElems.root and self.guiElems.root.valid then
+      self.guiElems.root.destroy()
+    end
+  end,
+
+  OnTick = function(self)
+    self.curRefreshCooldown = self.curRefreshCooldown - 1
+
+    if self.curRefreshCooldown == 0 then
+      self.curRefreshCooldown = self.refreshCooldown
+      self:refreshBtnList()
+    end
+  end,
+
+  OnPlayerChangedForce = function(self, player)
+    if player == self.player then
+      self.guiElems.root.destroy()
+      self.guiElems = {parent = self.guiElems.parent}
+      self:buildGui()
+    end
+  end,
+
+  OnGuiClick = function(self, e)
+    local name = e.element.name
+
+    if name:match("^" .. self.prefix .. "btn_%d+$") then
+      local ID = tonumber(e.element.name:match("%d+"))
+
+      for k, curBtn in pairs(self.guiElems.btns) do
+        if curBtn.tag.tag_number == ID then
+          if curBtn.tag.valid then
+            self.manager:OnChildEvent(self, "selectedPosition", curBtn.tag.position)
+          end
+          break
+        end
+      end
+
+    elseif name == self.prefix .. "rootFrame" and e.button == defines.mouse_button_type.right then
+      self.manager:OnChildEvent(self, "cancel")
+
+    elseif name == self.prefix .. "searchFieldClearBtn" then
+      self.guiElems.searchField.text = ""
+      self:OnGuiTextChanged({element = self.guiElems.searchField})
+    end
+  end,
+
+  OnGuiTextChanged = function(self, e)
+    local name = e.element.name
+    local newText = e.element.text
+
+    if name == self.prefix .. "searchField" then
+      if newText:contains(self.lastSearchFieldText) then
+        self:filterBtnList(newText)
+      else
+        self:buildBtnList()
+      end
+
+      self.lastSearchFieldText = newText
+    end
+  end,
+
+  removeBtnIndex = function(self, index)
+    self.guiElems.btns[index].btn.destroy()
+    table.remove(self.guiElems.btns, index)
+  end,
+
+  filterBtnList = function(self, filterStr)
+    for i = #self.guiElems.btns, 1, -1 do --iterate backwards so table.remove doesnt mess up the indices
+      local curBtn = self.guiElems.btns[i]
+      if not curBtn.text:contains(filterStr) then
+        self:removeBtnIndex(i)
+      end
+    end
+    self:setNothingAvailableIfNecessary()
+  end,
+
+  refreshBtnList = function(self)
+    local allTags = self:getFilteredChartTags()
+
+    local numNewTags = #allTags
+    local newTags = {}
+    for k,v in pairs(allTags) do
+      newTags[v.tag_number] = v
+    end
+
+    for i = #self.guiElems.btns, 1, -1 do --iterate backwards so table.remove doesnt mess up the indices
+      local curBtn = self.guiElems.btns[i]
+
+      if not curBtn.tag.valid then
+        self:removeBtnIndex(i)
+      
+      else
+        if newTags[curBtn.tag.tag_number] then
+          newTags[curBtn.tag.tag_number] = nil
+          numNewTags = numNewTags - 1
+        end
+
+        if curBtn.text ~= curBtn.tag.text then
+          curBtn.text = curBtn.tag.text
+          curBtn.btn.caption = "                " .. curBtn.tag.text
+        end
+
+        if not curBtn.icon and curBtn.tag.icon then
+          curBtn.icon, curBtn.iconType, curBtn.iconName = self:buildIconFromTag(curBtn.btn, curBtn.tag)
+        
+        elseif curBtn.icon and not curBtn.tag.icon then
+          curBtn.icon.destroy()
+          curBtn.icon, curBtn.iconType, curBtn.iconName = nil, nil, nil
+
+        elseif curBtn.icon and (curBtn.iconType ~= curBtn.tag.icon.type or curBtn.iconName ~= curBtn.tag.icon.name) then
+          curBtn.icon.destroy()
+          curBtn.icon, curBtn.iconType, curBtn.iconName = self:buildIconFromTag(curBtn.btn, curBtn.tag)
+        end
+      end
+    end
+
+    if numNewTags > 0 then
+      if #allTags > 666 then
+        for k, curTag in pairs(newTags) do
+          table.insert(self.guiElems.btns, self:buildBtnFromTag(self.guiElems.table, curTag))
+        end
+
+      else
+        self:buildBtnList(allTags)
+      end
+    end
+
+    self:setNothingAvailableIfNecessary()
+  end,
+
+  setNothingAvailableIfNecessary = function(self)
+    local els = self.guiElems
+    local listIsEmpty = #els.btns == 0
+
+    if listIsEmpty and not els.nothingAvailable then
+      els.nothingAvailable = els.scroller.add
+      {
+        type = "label",
+        name = self.prefix .. "nothingAvailable",
+        caption = "NO MAP MARKERS AVAILABLE",
+      }
+      els.nothingAvailable.style.font = "default-bold"
+      els.nothingAvailable.style.font_color = {r = 1, g = 0, b = 0}
+
+    elseif not listIsEmpty and els.nothingAvailable then
+      els.nothingAvailable.destroy()
+      els.nothingAvailable = nil
+    end
+  end,
+
+  getFilteredChartTags = function(self)
+    local tagList = self.player.force.find_chart_tags(self.player.surface)
+
+    for i = #tagList, 1, -1 do
+      if not tagList[i].text:contains(self.guiElems.searchField.text) then
+        table.remove(tagList, i)
+      end
+    end
+
+    return tagList
+  end,
+
+  buildIconFromTag = function(self, parent, tag)
+    local sprite
+    if tag.icon.type == "virtual" then
+      sprite = "virtual-signal" .. "/" .. tag.icon.name
+    else
+      sprite = tag.icon.type .. "/" .. tag.icon.name
+    end
+
+    local icon = parent.add
+    {
+      type = "sprite",
+      name = self.prefix .. "icon",
+      sprite = sprite,
+    }
+
+    return icon, tag.icon.type, tag.icon.name
+  end,
+
+  buildBtnFromTag = function(self, parent, tag)
+    local btn = parent.add
+    {
+      type = "button",
+      name = self.prefix .. "btn_" .. tostring(tag.tag_number),
+      style = "heli-listbox_button",
+      caption = "                " .. tag.text,
+    }
+    btn.style.minimal_height = 38
+    btn.style.minimal_width = 290
+
+    local icon, iconType, iconName = nil, nil, nil
+    if tag.icon then
+      icon, iconType, iconName = self:buildIconFromTag(btn, tag)
+    end
+
+    return {
+      btn = btn,
+      icon = icon,
+
+      tag = tag,
+      
+      text = tag.text,    
+      iconType = iconType,
+      iconName = iconName,
+    }
+  end,
+
+  buildBtnList = function(self, _tagList)
+    local tagList = _tagList or self:getFilteredChartTags()
+
+    table.sort(tagList, self.tagCompareCB)
+
+    self.guiElems.btns = {}
+    self.guiElems.table.clear()
+    for k, curTag in pairs(tagList) do
+      table.insert(self.guiElems.btns, self:buildBtnFromTag(self.guiElems.table, curTag))
+    end
+    
+    self:setNothingAvailableIfNecessary()
+  end,
+
+  tagCompareCB = function(a, b)
+    local aText = a.text ~= ""
+    local aIcon = a.icon
+
+    local bText = b.text ~= ""
+    local bIcon = b.icon
+
+    local sameText = a.text == b.text
+
+    if aText and bText then --both have text
+      if sameText then
+        return aIcon and not bIcon
+      end
+
+      return a.text < b.text
+
+    elseif aText then --only a has text
+      return true
+
+    elseif bText then --only b has text
+      return false
+
+    --neither has text
+
+    elseif aIcon and not bIcon then --only a has icon
+      return true
+    end
+
+    return false
+  end,
+
+  buildGui = function(self)
+    self.guiElems.root = self.guiElems.parent.add
+    {
+      type = "frame",
+      name = self.prefix .. "rootFrame",
+      caption = {"heli-gui-markerSelection-frame-caption"},
+      direction = "vertical",
+      style = "frame",
+      tooltip = {"heli-gui-frame-tt"},
+    }
+
+    self.guiElems.searchFieldFlow = self.guiElems.root.add
+    {
+      type = "flow",
+      name = self.prefix .. "searchFieldFlow",
+      direction = "horizontal",
+
+    }
+
+      self.guiElems.searchField = self.guiElems.searchFieldFlow.add
+      {
+        type = "textfield",
+        name = self.prefix .. "searchField",
+        style = "search_textfield_with_fixed_width",
+      }
+      self.guiElems.searchField.style.left_padding = 22
+      self.guiElems.searchField.style.minimal_height = 26
+      self.guiElems.searchField.style.maximal_height = 32
+
+      self.lastSearchFieldText = ""
+      
+        self.guiElems.searchField.add{
+          type = "sprite",
+          name = self.prefix .. "searchIcon",
+          sprite = "heli_search_icon",
+          --style = "heli_search_icon_style",
+        }
+
+
+      self.guiElems.searchFieldClearBtn = self.guiElems.searchFieldFlow.add
+      {
+        type = "button",
+        name = self.prefix .. "searchFieldClearBtn",
+        style = "heli-clear_text_button",
+      }
+    
+
+    self.guiElems.scroller = self.guiElems.root.add
+    {
+      type = "scroll-pane",
+      name = self.prefix .. "scroller",
+    }
+
+    self.guiElems.scroller.style.maximal_width = 1000
+    self.guiElems.scroller.style.maximal_height = 600
+
+    self.guiElems.table = self.guiElems.scroller.add
+    {
+      type = "flow",
+      name = self.prefix .. "flow",
+      style = "achievements_vertical_flow",
+      direction = "vertical",
+    }
+
+    self:buildBtnList()
+  end,
 }

--- a/logic/gui/playerSelectionGui.lua
+++ b/logic/gui/playerSelectionGui.lua
@@ -2,135 +2,135 @@ mod_gui = require("mod-gui")
 
 playerSelectionGui =
 {
-	prefix = "heli_playerSelectionGui_",
+  prefix = "heli_playerSelectionGui_",
 
-	new = function(mgr, p)
-		obj = 
-		{
-			valid = true,
-			manager = mgr,
-			player = p,
+  new = function(mgr, p)
+    obj = 
+    {
+      valid = true,
+      manager = mgr,
+      player = p,
 
-			guiElems = 
-			{
-				parent = mod_gui.get_frame_flow(p),
-			},
-			prefix = "heli_playerSelectionGui_",
-		}
+      guiElems = 
+      {
+        parent = mod_gui.get_frame_flow(p),
+      },
+      prefix = "heli_playerSelectionGui_",
+    }
 
-		setmetatable(obj, {__index = playerSelectionGui})
-		obj:buildGui()
+    setmetatable(obj, {__index = playerSelectionGui})
+    obj:buildGui()
 
-		return obj
-	end,
+    return obj
+  end,
 
-	destroy = function(self)
-		self.valid = false
-	
-		if self.guiElems.root and self.guiElems.root.valid then
-			self.guiElems.root.destroy()
-		end
-	end,
+  destroy = function(self)
+    self.valid = false
+  
+    if self.guiElems.root and self.guiElems.root.valid then
+      self.guiElems.root.destroy()
+    end
+  end,
 
-	OnGuiClick = function(self, e)
-		local name = e.element.name
+  OnGuiClick = function(self, e)
+    local name = e.element.name
 
-		if name:match("^" .. self.prefix .. "btn_.+$") then
-			if e.shift then
-				self.manager:OnChildEvent(self, "selectedPosition", searchInTable(self.guiElems.btns, e.element, "btn").player.position)
-			else
-				self.manager:OnChildEvent(self, "selectedPlayer", searchInTable(self.guiElems.btns, e.element, "btn").player)
-			end
-			
-		elseif name == self.prefix .. "rootFrame" and e.button == defines.mouse_button_type.right then
-			self.manager:OnChildEvent(self, "cancel")
-		end
-	end,
+    if name:match("^" .. self.prefix .. "btn_.+$") then
+      if e.shift then
+        self.manager:OnChildEvent(self, "selectedPosition", searchInTable(self.guiElems.btns, e.element, "btn").player.position)
+      else
+        self.manager:OnChildEvent(self, "selectedPlayer", searchInTable(self.guiElems.btns, e.element, "btn").player)
+      end
+      
+    elseif name == self.prefix .. "rootFrame" and e.button == defines.mouse_button_type.right then
+      self.manager:OnChildEvent(self, "cancel")
+    end
+  end,
 
-	OnPlayerDied = function(self, player)
-		self:removeBtnByPlayer(player)
-	end,
+  OnPlayerDied = function(self, player)
+    self:removeBtnByPlayer(player)
+  end,
 
-	OnPlayerLeftGame = function(self, player)
-		self:removeBtnByPlayer(player)
-	end,
+  OnPlayerLeftGame = function(self, player)
+    self:removeBtnByPlayer(player)
+  end,
 
-	OnPlayerRespawned = function(self, player)
-		if player.force == self.player.force then
-			table.insert(self.guiElems.btns, self:buildBtnFromPlayer(self.guiElems.flow, player))
-		end
-	end,
+  OnPlayerRespawned = function(self, player)
+    if player.force == self.player.force then
+      table.insert(self.guiElems.btns, self:buildBtnFromPlayer(self.guiElems.flow, player))
+    end
+  end,
 
-	OnPlayerChangedForce = function(self, player)
-		if player == self.player then
-			self.guiElems.root.destroy()
-			self.guiElems = {parent = self.guiElems.parent}
-			self:buildGui()
-		else
-			self:removeBtnByPlayer(player)
-		end
-	end,
+  OnPlayerChangedForce = function(self, player)
+    if player == self.player then
+      self.guiElems.root.destroy()
+      self.guiElems = {parent = self.guiElems.parent}
+      self:buildGui()
+    else
+      self:removeBtnByPlayer(player)
+    end
+  end,
 
-	removeBtnByPlayer = function(self, player)
-		local i = searchIndexInTable(self.guiElems.btns, player, "player")
-		if i then
-			self.guiElems.btns[i].btn.destroy()
-			table.remove(self.guiElems.btns, i)
-		end
-	end,
+  removeBtnByPlayer = function(self, player)
+    local i = searchIndexInTable(self.guiElems.btns, player, "player")
+    if i then
+      self.guiElems.btns[i].btn.destroy()
+      table.remove(self.guiElems.btns, i)
+    end
+  end,
 
-	buildBtnFromPlayer = function(self, parent, player)
-		local btn = parent.add
-		{
-			type = "button",
-			name = self.prefix .. "btn_" .. player.name,
-			style = "heli-listbox_button",
-			caption = player.name,
-			tooltip = {"heli-gui-playerSelection-listbox-btn-tt"},
-		}
-		btn.style.minimal_width = 290
+  buildBtnFromPlayer = function(self, parent, player)
+    local btn = parent.add
+    {
+      type = "button",
+      name = self.prefix .. "btn_" .. player.name,
+      style = "heli-listbox_button",
+      caption = player.name,
+      tooltip = {"heli-gui-playerSelection-listbox-btn-tt"},
+    }
+    btn.style.minimal_width = 290
 
-		return {
-			btn = btn,
-			player = player,
-		}
-	end,
+    return {
+      btn = btn,
+      player = player,
+    }
+  end,
 
-	buildGui = function(self)
-		local els = self.guiElems
+  buildGui = function(self)
+    local els = self.guiElems
 
-		els.root = els.parent.add
-		{
-			type = "frame",
-			name = self.prefix .. "rootFrame",
-			caption = {"heli-gui-playerSelection-frame-caption"},
-			style = "frame",
-			tooltip = {"heli-gui-frame-tt"},
-		}
+    els.root = els.parent.add
+    {
+      type = "frame",
+      name = self.prefix .. "rootFrame",
+      caption = {"heli-gui-playerSelection-frame-caption"},
+      style = "frame",
+      tooltip = {"heli-gui-frame-tt"},
+    }
 
-		els.scroller = els.root.add
-		{
-			type = "scroll-pane",
-			name = self.prefix .. "scroller",
-		}
+    els.scroller = els.root.add
+    {
+      type = "scroll-pane",
+      name = self.prefix .. "scroller",
+    }
 
-		els.scroller.style.maximal_width = 1000
-		els.scroller.style.maximal_height = 600
+    els.scroller.style.maximal_width = 1000
+    els.scroller.style.maximal_height = 600
 
-		els.flow = els.scroller.add
-		{
-			type = "flow",
-			name = self.prefix .. "flow",
-			style = "achievements_vertical_flow",
-			direction = "vertical",
-		}
+    els.flow = els.scroller.add
+    {
+      type = "flow",
+      name = self.prefix .. "flow",
+      style = "achievements_vertical_flow",
+      direction = "vertical",
+    }
 
-		els.btns = {}
-		for i, curPlayer in pairs(game.connected_players) do
-			if curPlayer.controller_type == defines.controllers.character and curPlayer.character then
-				table.insert(els.btns, self:buildBtnFromPlayer(els.flow, curPlayer))
-			end
-		end
-		
-	end,
+    els.btns = {}
+    for i, curPlayer in pairs(game.connected_players) do
+      if curPlayer.controller_type == defines.controllers.character and curPlayer.character then
+        table.insert(els.btns, self:buildBtnFromPlayer(els.flow, curPlayer))
+      end
+    end
+    
+  end,
 }

--- a/logic/gui/remoteGui.lua
+++ b/logic/gui/remoteGui.lua
@@ -4,175 +4,175 @@ require("logic.gui.markerSelectionGui")
 require("logic.gui.heliPadSelectionGui")
 
 function setRemoteBtn(p, show)
-	local flow = mod_gui.get_button_flow(p)
+  local flow = mod_gui.get_button_flow(p)
 
-	if show and not flow.heli_remote_btn then
-		flow.add
-		{
-			type = "sprite-button",
-			name = "heli_remote_btn",
-			sprite = "item/heli-remote-equipment",
-			style = mod_gui.button_style,
-			tooltip = {"heli-gui-remote-btn-tt"},
-		}
+  if show and not flow.heli_remote_btn then
+    flow.add
+    {
+      type = "sprite-button",
+      name = "heli_remote_btn",
+      sprite = "item/heli-remote-equipment",
+      style = mod_gui.button_style,
+      tooltip = {"heli-gui-remote-btn-tt"},
+    }
 
-	elseif (not show) and flow.heli_remote_btn and flow.heli_remote_btn.valid then
-		flow.heli_remote_btn.destroy()
+  elseif (not show) and flow.heli_remote_btn and flow.heli_remote_btn.valid then
+    flow.heli_remote_btn.destroy()
 
-		local i = searchIndexInTable(global.remoteGuis, p, "player")
-		if i then
-			global.remoteGuis[i]:destroy()
-			table.remove(global.remoteGuis, i)
-		end
-	end
+    local i = searchIndexInTable(global.remoteGuis, p, "player")
+    if i then
+      global.remoteGuis[i]:destroy()
+      table.remove(global.remoteGuis, i)
+    end
+  end
 end
 
 function toggleRemoteGui(player)
-	local i = searchIndexInTable(global.remoteGuis, player, "player")
+  local i = searchIndexInTable(global.remoteGuis, player, "player")
 
-	if not i then
-		insertInGlobal("remoteGuis", remoteGui.new(player))
-	else
-		global.remoteGuis[i]:destroy()
-		table.remove(global.remoteGuis, i)
-	end
+  if not i then
+    insertInGlobal("remoteGuis", remoteGui.new(player))
+  else
+    global.remoteGuis[i]:destroy()
+    table.remove(global.remoteGuis, i)
+  end
 end
 
 function OnHeliControllerCreated(controller)
-	callInGlobal("remoteGuis", "OnHeliControllerCreated", controller)
+  callInGlobal("remoteGuis", "OnHeliControllerCreated", controller)
 end
 
 function OnHeliControllerDestroyed(controller)
-	callInGlobal("remoteGuis", "OnHeliControllerDestroyed", controller)
+  callInGlobal("remoteGuis", "OnHeliControllerDestroyed", controller)
 end
 
 
 remoteGui = 
 {
-	new = function(p)
-		local obj = {
-			valid = true,
+  new = function(p)
+    local obj = {
+      valid = true,
 
-			player = p,
+      player = p,
 
-			guis = {}
-		}
+      guis = {}
+    }
 
-		setmetatable(obj, {__index = remoteGui})
-	
-		obj.guis.heliSelection = heliSelectionGui.new(obj, p)
-		return obj
-	end,
+    setmetatable(obj, {__index = remoteGui})
+  
+    obj.guis.heliSelection = heliSelectionGui.new(obj, p)
+    return obj
+  end,
 
-	destroy = function(self)
-		self.valid = false
-		for k, curGui in pairs(self.guis) do
-			if curGui.valid then
-				curGui:destroy()
-			end
-		end
-	end,
+  destroy = function(self)
+    self.valid = false
+    for k, curGui in pairs(self.guis) do
+      if curGui.valid then
+        curGui:destroy()
+      end
+    end
+  end,
 
-	hasMyPrefix = function(str)
-		return string.startswith(str, heliSelectionGui.prefix) or 
-			string.startswith(str, playerSelectionGui.prefix) or 
-			string.startswith(str, markerSelectionGui.prefix) or
-			string.startswith(str, heliPadSelectionGui.prefix)
-	end,
+  hasMyPrefix = function(str)
+    return string.startswith(str, heliSelectionGui.prefix) or 
+      string.startswith(str, playerSelectionGui.prefix) or 
+      string.startswith(str, markerSelectionGui.prefix) or
+      string.startswith(str, heliPadSelectionGui.prefix)
+  end,
 
-	OnTick = function(self)
-		if not self.player.valid then
-			self:destroy()
-		else
-			for k, curGui in pairs(self.guis) do
-				if curGui.OnTick then
-					curGui:OnTick()
-				end
-			end
-		end
-	end,
+  OnTick = function(self)
+    if not self.player.valid then
+      self:destroy()
+    else
+      for k, curGui in pairs(self.guis) do
+        if curGui.OnTick then
+          curGui:OnTick()
+        end
+      end
+    end
+  end,
 
-	OnGuiClick = function(self, e)
-		local name = e.element.name
+  OnGuiClick = function(self, e)
+    local name = e.element.name
 
-		for k, curGui in pairs(self.guis) do
-			if name:match("^" .. curGui.prefix .. ".+") and curGui.OnGuiClick then
-				curGui:OnGuiClick(e)
-			end
-		end
-	end,
+    for k, curGui in pairs(self.guis) do
+      if name:match("^" .. curGui.prefix .. ".+") and curGui.OnGuiClick then
+        curGui:OnGuiClick(e)
+      end
+    end
+  end,
 
-	OnGuiTextChanged = function(self, e)
-		local name = e.element.name
+  OnGuiTextChanged = function(self, e)
+    local name = e.element.name
 
-		for k, curGui in pairs(self.guis) do
-			if name:match("^" .. curGui.prefix .. ".+") and curGui.OnGuiTextChanged then
-				curGui:OnGuiTextChanged(e)
-			end
-		end
-	end,
+    for k, curGui in pairs(self.guis) do
+      if name:match("^" .. curGui.prefix .. ".+") and curGui.OnGuiTextChanged then
+        curGui:OnGuiTextChanged(e)
+      end
+    end
+  end,
 
-	OnChildEvent = function(self, child, evtName, ...)
-		if evtName == "showTargetSelectionGui" then
-			local prot = ...
-			self.guis.heliSelection:setVisible(false)
-			self.guis.targetSelection = prot.new(self, self.player)
+  OnChildEvent = function(self, child, evtName, ...)
+    if evtName == "showTargetSelectionGui" then
+      local prot = ...
+      self.guis.heliSelection:setVisible(false)
+      self.guis.targetSelection = prot.new(self, self.player)
 
-		elseif evtName == "selectedPosition" then
-			local pos = ...
-			local heli = self.guis.heliSelection.selectedCam.heli
+    elseif evtName == "selectedPosition" then
+      local pos = ...
+      local heli = self.guis.heliSelection.selectedCam.heli
 
-			assignHeliController(self.player, heli, pos, false)
+      assignHeliController(self.player, heli, pos, false)
 
-			if child ~= self.guis.heliSelection then
-				child:destroy()
-				self.guis.targetSelection = nil
-			end
-			self.guis.heliSelection:setVisible(true)
-		
-		elseif evtName == "selectedPlayer" then
-			local p = ...
-			local heli = self.guis.heliSelection.selectedCam.heli
+      if child ~= self.guis.heliSelection then
+        child:destroy()
+        self.guis.targetSelection = nil
+      end
+      self.guis.heliSelection:setVisible(true)
+    
+    elseif evtName == "selectedPlayer" then
+      local p = ...
+      local heli = self.guis.heliSelection.selectedCam.heli
 
-			assignHeliController(self.player, heli, p, true)
+      assignHeliController(self.player, heli, p, true)
 
-			if child ~= self.guis.heliSelection then
-				child:destroy()
-				self.guis.targetSelection = nil
-			end
-			self.guis.heliSelection:setVisible(true)
+      if child ~= self.guis.heliSelection then
+        child:destroy()
+        self.guis.targetSelection = nil
+      end
+      self.guis.heliSelection:setVisible(true)
 
-		elseif evtName == "OnSelectedHeliIsInvalid" then
-			if self.guis.targetSelection then
-				self.guis.targetSelection:destroy()
-				self.guis.heliSelection:setVisible(true)
-			end
+    elseif evtName == "OnSelectedHeliIsInvalid" then
+      if self.guis.targetSelection then
+        self.guis.targetSelection:destroy()
+        self.guis.heliSelection:setVisible(true)
+      end
 
-		elseif evtName == "cancel" then
-			if child == self.guis.heliSelection then
-				self:destroy()
-				removeInGlobal("remoteGuis", self)
-			else
-				child:destroy()
-				self.guis.targetSelection = nil
-				self.guis.heliSelection:setVisible(true)
-			end
-		end
-	end,
+    elseif evtName == "cancel" then
+      if child == self.guis.heliSelection then
+        self:destroy()
+        removeInGlobal("remoteGuis", self)
+      else
+        child:destroy()
+        self.guis.targetSelection = nil
+        self.guis.heliSelection:setVisible(true)
+      end
+    end
+  end,
 
-	OnHeliRemoved = function(self, heli)
-		for _,gui in pairs(self.guis) do
-			if gui.OnHeliRemoved then
-				gui:OnHeliRemoved(heli)
-			end
-		end
-	end,
+  OnHeliRemoved = function(self, heli)
+    for _,gui in pairs(self.guis) do
+      if gui.OnHeliRemoved then
+        gui:OnHeliRemoved(heli)
+      end
+    end
+  end,
 
-	OnHeliBuilt = function(self, heli)
-		for _,gui in pairs(self.guis) do
-			if gui.OnHeliBuilt then
-				gui:OnHeliBuilt(heli)
-			end
-		end
-	end,
+  OnHeliBuilt = function(self, heli)
+    for _,gui in pairs(self.guis) do
+      if gui.OnHeliBuilt then
+        gui:OnHeliBuilt(heli)
+      end
+    end
+  end,
 }

--- a/logic/heliAttack.lua
+++ b/logic/heliAttack.lua
@@ -1,49 +1,49 @@
 heliAttack =
 {
-	type = "heliAttack",
-	bodyOffset = 5,
-	rotorOffset = 5.1,
+  type = "heliAttack",
+  bodyOffset = 5,
+  rotorOffset = 5.1,
 
-	rotorRPFacceleration = 0.0002,
-	rotorMaxRPF = 240/60/60, --revolutions per frame
+  rotorRPFacceleration = 0.0002,
+  rotorMaxRPF = 240/60/60, --revolutions per frame
 
-	engineReduction = 7.5,
+  engineReduction = 7.5,
 
-	fuelSlots = 5,
+  fuelSlots = 5,
 
-	new = function(placementEnt)
-		local baseEnt = placementEnt.surface.create_entity{name = "heli-entity-_-", force = placementEnt.force, position = placementEnt.position}
+  new = function(placementEnt)
+    local baseEnt = placementEnt.surface.create_entity{name = "heli-entity-_-", force = placementEnt.force, position = placementEnt.position}
 
-		local childs =
-		{
-			bodyEnt = placementEnt.surface.create_entity{name = "heli-body-entity-_-", force = game.forces.neutral, position = {x = baseEnt.position.x, y = baseEnt.position.y + heliAttack.bodyOffset}},
-			rotorEnt = placementEnt.surface.create_entity{name = "rotor-entity-_-", force = game.forces.neutral, position = {x = baseEnt.position.x, y = baseEnt.position.y + heliAttack.rotorOffset}},
+    local childs =
+    {
+      bodyEnt = placementEnt.surface.create_entity{name = "heli-body-entity-_-", force = game.forces.neutral, position = {x = baseEnt.position.x, y = baseEnt.position.y + heliAttack.bodyOffset}},
+      rotorEnt = placementEnt.surface.create_entity{name = "rotor-entity-_-", force = game.forces.neutral, position = {x = baseEnt.position.x, y = baseEnt.position.y + heliAttack.rotorOffset}},
 
-			bodyEntShadow = placementEnt.surface.create_entity{name = "heli-shadow-entity-_-", force = game.forces.neutral, position = baseEnt.position},
-			rotorEntShadow = placementEnt.surface.create_entity{name = "rotor-shadow-entity-_-", force = game.forces.neutral, position = baseEnt.position},
+      bodyEntShadow = placementEnt.surface.create_entity{name = "heli-shadow-entity-_-", force = game.forces.neutral, position = baseEnt.position},
+      rotorEntShadow = placementEnt.surface.create_entity{name = "rotor-shadow-entity-_-", force = game.forces.neutral, position = baseEnt.position},
 
-			burnerEnt = placementEnt.surface.create_entity{name = "heli-burner-entity-_-", force = game.forces.neutral, position = {x = baseEnt.position.x, y = baseEnt.position.y + 1.3}},
+      burnerEnt = placementEnt.surface.create_entity{name = "heli-burner-entity-_-", force = game.forces.neutral, position = {x = baseEnt.position.x, y = baseEnt.position.y + 1.3}},
 
-			floodlightEnt = placementEnt.surface.create_entity{name = "heli-floodlight-entity-_-", force = game.forces.neutral, position = baseEnt.position},
-		}
+      floodlightEnt = placementEnt.surface.create_entity{name = "heli-floodlight-entity-_-", force = game.forces.neutral, position = baseEnt.position},
+    }
 
-		return heliBase.new(placementEnt, baseEnt, childs, {__index = heliAttack})
-	end,
+    return heliBase.new(placementEnt, baseEnt, childs, {__index = heliAttack})
+  end,
 }
 
 setmetatable(heliAttack, {__index = heliBase})
 
 heliEntityNames = heliEntityNames .. concatStrTable({
-	"heli-entity-_-",
-	"heli-body-entity-_-",
-	"heli-landed-collision-end-entity-_-",
-	"heli-landed-collision-side-entity-_-",
-	"heli-shadow-entity-_-",
-	"heli-flying-collision-entity-_-",
-	"heli-burner-entity-_-",
-	"heli-floodlight-entity-_-",
-	"rotor-entity-_-",
-	"rotor-shadow-entity-_-",
+  "heli-entity-_-",
+  "heli-body-entity-_-",
+  "heli-landed-collision-end-entity-_-",
+  "heli-landed-collision-side-entity-_-",
+  "heli-shadow-entity-_-",
+  "heli-flying-collision-entity-_-",
+  "heli-burner-entity-_-",
+  "heli-floodlight-entity-_-",
+  "rotor-entity-_-",
+  "rotor-shadow-entity-_-",
 }, ",")
 
 heliBaseEntityNames = heliBaseEntityNames .. "heli-entity-_-" .. ","

--- a/logic/heliBase.lua
+++ b/logic/heliBase.lua
@@ -3,105 +3,105 @@ require("logic.basicState")
 require("logic.emptyBoxCollider")
 
 function getHeliFromBaseEntity(ent)
-	for k,v in pairs(global.helis) do
-		if v.baseEnt == ent then
-			return v
-		end
-	end
+  for k,v in pairs(global.helis) do
+    if v.baseEnt == ent then
+      return v
+    end
+  end
 
-	return nil
+  return nil
 end
 
 function findNearestAvailableHeli(pos, force, requestingPlayer)
-	local nearestHeli = nil
-	local nearestDist = nil
+  local nearestHeli = nil
+  local nearestDist = nil
 
-	if global.helis then
-		for k, curHeli in pairs(global.helis) do
-			if curHeli.baseEnt.valid and
-				curHeli.baseEnt.force == force and
-					(not curHeli.baseEnt.get_driver() or (curHeli.hasRemoteController and curHeli.remoteController.driverIsBot)) then
+  if global.helis then
+    for k, curHeli in pairs(global.helis) do
+      if curHeli.baseEnt.valid and
+        curHeli.baseEnt.force == force and
+          (not curHeli.baseEnt.get_driver() or (curHeli.hasRemoteController and curHeli.remoteController.driverIsBot)) then
 
-				if not requestingPlayer or (not curHeli.remoteController or curHeli.remoteController.owner == requestingPlayer) then
-					local curDist = getDistance(pos, curHeli.baseEnt.position)
+        if not requestingPlayer or (not curHeli.remoteController or curHeli.remoteController.owner == requestingPlayer) then
+          local curDist = getDistance(pos, curHeli.baseEnt.position)
 
-					if (not nearestDist) or (nearestDist and curDist < nearestDist) then
-						nearestDist = curDist
-						nearestHeli = curHeli
-					end
-				end
-			end
-		end
-	end
+          if (not nearestDist) or (nearestDist and curDist < nearestDist) then
+            nearestDist = curDist
+            nearestHeli = curHeli
+          end
+        end
+      end
+    end
+  end
 
-	return nearestHeli, nearestDist
+  return nearestHeli, nearestDist
 end
 
 local frameFixes = {
-	0, 			--1
-	0.015625, 	--2
-	0.046875, 	--3
-	0.0625, 	--4
-	0.078125, 	--5
-	0.109375, 	--6
-	0.125, 		--7
-	0.140625, 	--8
-	0.15625, 	--9
-	0.171875, 	--10
-	0.1796875, 	--11
-	0.1875, 	--12
-	0.203125, 	--13
-	0.21875, 	--14
-	0.2265625, 	--15
-	0.234375, 	--16
-	0.25, 		--17
-	0.265625, 	--18
-	0.2734375, 	--19
-	0.28125, 	--20
-	0.296875, 	--21
-	0.3125, 	--22
-	0.3203125, 	--23
-	0.328125, 	--24
-	0.34375, 	--25
-	0.359375, 	--26
-	0.375, 		--27
-	0.390625, 	--28
-	0.40625, 	--29
-	0.4375, 	--30
-	0.453125, 	--31
-	0.46875, 	--32
-	0.5, 		--33
-	0.515625, 	--34
-	0.546875, 	--35
-	0.5625, 	--36
-	0.578125, 	--37
-	0.609375, 	--38
-	0.625, 		--39
-	0.640625, 	--40
-	0.65625, 	--41
-	0.671875, 	--42
-	0.6796875, 	--43
-	0.6875, 	--44
-	0.703125, 	--45
-	0.71875, 	--46
-	0.7265625, 	--47
-	0.734375, 	--48
-	0.75, 		--49
-	0.765625, 	--50
-	0.7734375, 	--51
-	0.78125, 	--52
-	0.796875, 	--53
-	0.8125, 	--54
-	0.8203125, 	--55
-	0.828125, 	--56
-	0.84375, 	--57
-	0.859375, 	--58
-	0.875, 		--59
-	0.890625, 	--60
-	0.90625, 	--61
-	0.9375, 	--62
-	0.953125, 	--63
-	0.984375, 	--64
+  0,       --1
+  0.015625,   --2
+  0.046875,   --3
+  0.0625,   --4
+  0.078125,   --5
+  0.109375,   --6
+  0.125,     --7
+  0.140625,   --8
+  0.15625,   --9
+  0.171875,   --10
+  0.1796875,   --11
+  0.1875,   --12
+  0.203125,   --13
+  0.21875,   --14
+  0.2265625,   --15
+  0.234375,   --16
+  0.25,     --17
+  0.265625,   --18
+  0.2734375,   --19
+  0.28125,   --20
+  0.296875,   --21
+  0.3125,   --22
+  0.3203125,   --23
+  0.328125,   --24
+  0.34375,   --25
+  0.359375,   --26
+  0.375,     --27
+  0.390625,   --28
+  0.40625,   --29
+  0.4375,   --30
+  0.453125,   --31
+  0.46875,   --32
+  0.5,     --33
+  0.515625,   --34
+  0.546875,   --35
+  0.5625,   --36
+  0.578125,   --37
+  0.609375,   --38
+  0.625,     --39
+  0.640625,   --40
+  0.65625,   --41
+  0.671875,   --42
+  0.6796875,   --43
+  0.6875,   --44
+  0.703125,   --45
+  0.71875,   --46
+  0.7265625,   --47
+  0.734375,   --48
+  0.75,     --49
+  0.765625,   --50
+  0.7734375,   --51
+  0.78125,   --52
+  0.796875,   --53
+  0.8125,   --54
+  0.8203125,   --55
+  0.828125,   --56
+  0.84375,   --57
+  0.859375,   --58
+  0.875,     --59
+  0.890625,   --60
+  0.90625,   --61
+  0.9375,   --62
+  0.953125,   --63
+  0.984375,   --64
 }
 
 --local modVersion = versionStrToInt(game.active_mods.HelicopterRevival)
@@ -114,1003 +114,1003 @@ local bobbingPeriod = 8*60
 local colliderMaxHealth = 999999
 
 local IsEntityBurnerOutOfFuel = function(ent)
-	return ent.burner.remaining_burning_fuel <= 0 and ent.burner.inventory.is_empty()
+  return ent.burner.remaining_burning_fuel <= 0 and ent.burner.inventory.is_empty()
 end
 
 local transferGridEquipment = function(srcEnt, destEnt)
-	if srcEnt.grid and destEnt.grid then --assume they have the same size and destEnt.grid is empty.
-		for i, equip in ipairs(srcEnt.grid.equipment) do
-			local newEquip = destEnt.grid.put{name = equip.name, position = equip.position}
+  if srcEnt.grid and destEnt.grid then --assume they have the same size and destEnt.grid is empty.
+    for i, equip in ipairs(srcEnt.grid.equipment) do
+      local newEquip = destEnt.grid.put{name = equip.name, position = equip.position}
 
-			if equip.type == "energy-shield-equipment" then newEquip.shield = equip.shield end
-			newEquip.energy = equip.energy
-		end
-		srcEnt.grid.clear()
-	end
+      if equip.type == "energy-shield-equipment" then newEquip.shield = equip.shield end
+      newEquip.energy = equip.energy
+    end
+    srcEnt.grid.clear()
+  end
 end
 
 heliEntityNames = ""
 heliBaseEntityNames = ""
 
 stateFuncs = {
-	landed = {
-		init = function(heli)
-			heli.baseEnt.effectivity_modifier = 0
-			heli.baseEnt.friction_modifier = 50
+  landed = {
+    init = function(heli)
+      heli.baseEnt.effectivity_modifier = 0
+      heli.baseEnt.friction_modifier = 50
 
-			heli.lockedBaseOrientation = heli.baseEnt.orientation
+      heli.lockedBaseOrientation = heli.baseEnt.orientation
 
-			heli.landedColliderCreationDelay = 2
+      heli.landedColliderCreationDelay = 2
 
-			heli:setFloodlightEntities(false)
+      heli:setFloodlightEntities(false)
 
-			for k, curGG in pairs(heli.gaugeGuis) do
-				curGG:setPointerNoise("gauge_fs", "speed", false)
-				curGG:setPointerNoise("gauge_hr", "height", false)
-				curGG:setPointerNoise("gauge_hr", "rpm", false)
-			end
+      for k, curGG in pairs(heli.gaugeGuis) do
+        curGG:setPointerNoise("gauge_fs", "speed", false)
+        curGG:setPointerNoise("gauge_hr", "height", false)
+        curGG:setPointerNoise("gauge_hr", "rpm", false)
+      end
 
-			heli:setFuelGaugeTarget(0, true)
-		end,
+      heli:setFuelGaugeTarget(0, true)
+    end,
 
-		OnTick = function(heli)
-			if heli.landedColliderCreationDelay > 0 then
-				if heli.landedColliderCreationDelay == 1 then
-					heli:setCollider("landed")
-					heli:updateEntityRotations()
-				end
+    OnTick = function(heli)
+      if heli.landedColliderCreationDelay > 0 then
+        if heli.landedColliderCreationDelay == 1 then
+          heli:setCollider("landed")
+          heli:updateEntityRotations()
+        end
 
-				heli.landedColliderCreationDelay = heli.landedColliderCreationDelay - 1
-			end
+        heli.landedColliderCreationDelay = heli.landedColliderCreationDelay - 1
+      end
 
-			if heli.baseEnt.orientation ~= heli.lockedBaseOrientation then
-				heli.baseEnt.orientation = heli.lockedBaseOrientation
-			end
+      if heli.baseEnt.orientation ~= heli.lockedBaseOrientation then
+        heli.baseEnt.orientation = heli.lockedBaseOrientation
+      end
 
-			local speed = heli.baseEnt.speed
-			if speed > 0.25 then --54 km/h
-				local players = getCarPlayers(heli.baseEnt)
+      local speed = heli.baseEnt.speed
+      if speed > 0.25 then --54 km/h
+        local players = getCarPlayers(heli.baseEnt)
 
-				heli.baseEnt.damage(speed * 210, game.forces.neutral)
+        heli.baseEnt.damage(speed * 210, game.forces.neutral)
 
-				if not heli.baseEnt.valid then --destroy event might already be executed
-					heli:dealCrashDamage(players, speed)
+        if not heli.baseEnt.valid then --destroy event might already be executed
+          heli:dealCrashDamage(players, speed)
 
-					return false
-				end
-			end
-		end,
+          return false
+        end
+      end
+    end,
 
-		OnUp = function(heli)
-			heli:changeState(heli.engineStarting)
-		end,
-	},
-	engineStarting = {
-		init = function(heli)
-			heli.lockedBaseOrientation = heli.baseEnt.orientation
+    OnUp = function(heli)
+      heli:changeState(heli.engineStarting)
+    end,
+  },
+  engineStarting = {
+    init = function(heli)
+      heli.lockedBaseOrientation = heli.baseEnt.orientation
 
-			heli:setRotorTargetRPF(heli.rotorMaxRPF)
+      heli:setRotorTargetRPF(heli.rotorMaxRPF)
 
-			if not (heli.burnerDriver and heli.burnerDriver.valid) then
-				heli.burnerDriver = heli.surface.create_entity{name="character", force = game.forces.neutral, position = heli.baseEnt.position}
-				heli.childs.burnerEnt.set_driver(heli.burnerDriver)
-			end
+      if not (heli.burnerDriver and heli.burnerDriver.valid) then
+        heli.burnerDriver = heli.surface.create_entity{name="character", force = game.forces.neutral, position = heli.baseEnt.position}
+        heli.childs.burnerEnt.set_driver(heli.burnerDriver)
+      end
 
-			if heli.floodlightEnabled then
-				heli:setFloodlightEntities(true)
-			end
+      if heli.floodlightEnabled then
+        heli:setFloodlightEntities(true)
+      end
 
-			for k, curGG in pairs(heli.gaugeGuis) do
-				curGG:setPointerNoise("gauge_fs", "speed", true, 5)
-				curGG:setPointerNoise("gauge_hr", "height", true, 0.5, 0.2, 12, 18)
-				curGG:setPointerNoise("gauge_hr", "rpm", true, 50)
-			end
+      for k, curGG in pairs(heli.gaugeGuis) do
+        curGG:setPointerNoise("gauge_fs", "speed", true, 5)
+        curGG:setPointerNoise("gauge_hr", "height", true, 0.5, 0.2, 12, 18)
+        curGG:setPointerNoise("gauge_hr", "rpm", true, 50)
+      end
 
-			heli.lastFuelGaugeTargetVal = 1
-		end,
+      heli.lastFuelGaugeTargetVal = 1
+    end,
 
-		OnTick = function(heli)
-			if heli.baseEnt.orientation ~= heli.lockedBaseOrientation then
-				heli.baseEnt.orientation = heli.lockedBaseOrientation
-			end
+    OnTick = function(heli)
+      if heli.baseEnt.orientation ~= heli.lockedBaseOrientation then
+        heli.baseEnt.orientation = heli.lockedBaseOrientation
+      end
 
-			heli:handleFuelConsumption()
-			heli:landIfEmpty()
+      heli:handleFuelConsumption()
+      heli:landIfEmpty()
 
-			if heli.rotorRPF == heli.rotorMaxRPF then
-				heli:changeState(heli.ascend)
-			end
-		end,
-	},
-	ascend = {
-		init = function(heli)
-			heli.baseEnt.effectivity_modifier = 1
-			heli.baseEnt.friction_modifier = 1
+      if heli.rotorRPF == heli.rotorMaxRPF then
+        heli:changeState(heli.ascend)
+      end
+    end,
+  },
+  ascend = {
+    init = function(heli)
+      heli.baseEnt.effectivity_modifier = 1
+      heli.baseEnt.friction_modifier = 1
 
-			local time = heli:setTargetHeight(heli.maxHeight)
-			--heli.bobbingAnimator = basicAnimator.new(heli.curBobbing, 0, time*60, "linear")
+      local time = heli:setTargetHeight(heli.maxHeight)
+      --heli.bobbingAnimator = basicAnimator.new(heli.curBobbing, 0, time*60, "linear")
 
-			heli:setCollider("flying")
-		end,
+      heli:setCollider("flying")
+    end,
 
-		OnTick = function(heli)
-			heli:updateEntityRotations()
-			heli:handleFuelConsumption()
-			heli:landIfEmpty()
-			heli:handleInserters()
+    OnTick = function(heli)
+      heli:updateEntityRotations()
+      heli:handleFuelConsumption()
+      heli:landIfEmpty()
+      heli:handleInserters()
 
-			--if heli.bobbingAnimator and not heli.bobbingAnimator.isDone then
-			--	heli.curBobbing = heli.bobbingAnimator:nextFrame()
-			--end
+      --if heli.bobbingAnimator and not heli.bobbingAnimator.isDone then
+      --  heli.curBobbing = heli.bobbingAnimator:nextFrame()
+      --end
 
-			if heli.height > maxCollisionHeight then
-				heli:setCollider("none")
-			end
+      if heli.height > maxCollisionHeight then
+        heli:setCollider("none")
+      end
 
-			if heli.height == heli.maxHeight then
-				heli:changeState(heli.hovering)
-			end
-		end,
+      if heli.height == heli.maxHeight then
+        heli:changeState(heli.hovering)
+      end
+    end,
 
-		OnMaxHeightChanged = function(heli)
-			heli:setTargetHeight(heli.maxHeight)
-		end,
-	},
-	hovering = {
-		init = function(heli)
-			--heli.bobbingAnimator = basicAnimator.new(0, maxBobbing, bobbingPeriod, "cyclicSine")
-		end,
+    OnMaxHeightChanged = function(heli)
+      heli:setTargetHeight(heli.maxHeight)
+    end,
+  },
+  hovering = {
+    init = function(heli)
+      --heli.bobbingAnimator = basicAnimator.new(0, maxBobbing, bobbingPeriod, "cyclicSine")
+    end,
 
-		OnTick = function(heli)
-			heli:updateEntityRotations()
-			heli:handleFuelConsumption()
-			heli:landIfEmpty()
-			heli:handleInserters()
+    OnTick = function(heli)
+      heli:updateEntityRotations()
+      heli:handleFuelConsumption()
+      heli:landIfEmpty()
+      heli:handleInserters()
 
-			--[[
-			local isDone
-			heli.curBobbing, isDone = heli.bobbingAnimator:nextFrame()
+      --[[
+      local isDone
+      heli.curBobbing, isDone = heli.bobbingAnimator:nextFrame()
 
-			if isDone then
-				heli.bobbingAnimator:reset()
-			end
-			]]
-		end,
+      if isDone then
+        heli.bobbingAnimator:reset()
+      end
+      ]]
+    end,
 
-		OnMaxHeightChanged = function(heli)
-			heli:setTargetHeight(heli.maxHeight)
-		end,
-	},
-	descend = {
-		init = function(heli)
-			local time = heli:setTargetHeight(0)
-			--heli.bobbingAnimator = basicAnimator.new(heli.curBobbing, 0, time*60, "linear")
-		end,
+    OnMaxHeightChanged = function(heli)
+      heli:setTargetHeight(heli.maxHeight)
+    end,
+  },
+  descend = {
+    init = function(heli)
+      local time = heli:setTargetHeight(0)
+      --heli.bobbingAnimator = basicAnimator.new(heli.curBobbing, 0, time*60, "linear")
+    end,
 
-		deinit = function(heli)
-			heli:reactivateAllInserters()
-		end,
+    deinit = function(heli)
+      heli:reactivateAllInserters()
+    end,
 
-		OnTick = function(heli)
-			heli:updateEntityRotations()
-			heli:handleFuelConsumption()
-			heli:handleInserters()
+    OnTick = function(heli)
+      heli:updateEntityRotations()
+      heli:handleFuelConsumption()
+      heli:handleInserters()
 
-			--if heli.bobbingAnimator and not heli.bobbingAnimator.isDone then
-			--	heli.curBobbing = heli.bobbingAnimator:nextFrame()
-			--end
+      --if heli.bobbingAnimator and not heli.bobbingAnimator.isDone then
+      --  heli.curBobbing = heli.bobbingAnimator:nextFrame()
+      --end
 
-			if heli.height <= maxCollisionHeight and not (heli.childs.collisionEnt and heli.childs.collisionEnt.valid) then
-				heli:setCollider("flying")
-			end
+      if heli.height <= maxCollisionHeight and not (heli.childs.collisionEnt and heli.childs.collisionEnt.valid) then
+        heli:setCollider("flying")
+      end
 
-			if heli.height == 0 then
-				heli:changeState(heli.engineStopping)
-			end
-		end,
+      if heli.height == 0 then
+        heli:changeState(heli.engineStopping)
+      end
+    end,
 
-		OnUp = function(heli)
-			print("descend OnUp")
-			heli:changeState(heli.ascend)
-		end,
-	},
-	engineStopping = {
-		init = function(heli)
-			heli.childs.burnerEnt.set_driver(nil)
+    OnUp = function(heli)
+      print("descend OnUp")
+      heli:changeState(heli.ascend)
+    end,
+  },
+  engineStopping = {
+    init = function(heli)
+      heli.childs.burnerEnt.set_driver(nil)
 
-			if heli.burnerDriver and heli.burnerDriver.valid then
-				heli.burnerDriver.destroy()
-				heli.burnerDriver = nil
-			end
+      if heli.burnerDriver and heli.burnerDriver.valid then
+        heli.burnerDriver.destroy()
+        heli.burnerDriver = nil
+      end
 
-			heli:setRotorTargetRPF(0)
+      heli:setRotorTargetRPF(0)
 
-			heli:changeState(heli.landed)
-		end,
-	},
+      heli:changeState(heli.landed)
+    end,
+  },
 }
 
 heliBase = {
-	---------- default vals -----------
-	valid = true,
+  ---------- default vals -----------
+  valid = true,
 
-	goUp = false,
+  goUp = false,
 
-	startupProgress = 0,
-	height = 0,
-	targetHeight = 0,
-	maxHeight = 5,
-	curBobbing = 0,
+  startupProgress = 0,
+  height = 0,
+  targetHeight = 0,
+  maxHeight = 5,
+  curBobbing = 0,
 
-	heightSpeed = 0,
-	heightAcceleration = 0.001,
+  heightSpeed = 0,
+  heightAcceleration = 0.001,
 
-	maxHeightUperLimit = 20,
-	maxHeightLowerLimit = 3,
+  maxHeightUperLimit = 20,
+  maxHeightLowerLimit = 3,
 
-	rotorOrient = 0,
-	rotorRPF = 0,
-	rotorTargetRPF = 0,
+  rotorOrient = 0,
+  rotorRPF = 0,
+  rotorTargetRPF = 0,
 
-	fuelGaugeVal = 0,
-	fuelGaugeTargetVal = 0,
-	lastFuelGaugeTargetVal = 0,
-	fuelGaugeSpeed = 0.005,
+  fuelGaugeVal = 0,
+  fuelGaugeTargetVal = 0,
+  lastFuelGaugeTargetVal = 0,
+  fuelGaugeSpeed = 0.005,
 
-	gaugeGuis = {},
+  gaugeGuis = {},
 
-	hasLandedCollider = false,
-	landedColliderCreationDelay = 1, --frames. workaround for inserters trying to access collider inventory when created at the same time.
+  hasLandedCollider = false,
+  landedColliderCreationDelay = 1, --frames. workaround for inserters trying to access collider inventory when created at the same time.
 
-	floodlightEnabled = false,
+  floodlightEnabled = false,
 
-	baseEngineConsumption = 20000,
+  baseEngineConsumption = 20000,
 
-	inserterScanRadius = 5,
+  inserterScanRadius = 5,
 
-	fullTankFlightTime = 15 * 60 * 60, --in ticks
-	tankWarningRatio = 3 / 15, --3 min
-	tankCriticalWarningRatio = 0.5 / 15, --30s
+  fullTankFlightTime = 15 * 60 * 60, --in ticks
+  tankWarningRatio = 3 / 15, --3 min
+  tankCriticalWarningRatio = 0.5 / 15, --30s
 
-	------------------------------------------------------------
-
-	new = function(placementEnt, baseEnt, childEnts, mt)
-		transferGridEquipment(placementEnt, baseEnt)
-		baseEnt.health = placementEnt.health
-
-		local obj = {
-			version = versionStrToInt(game.active_mods.HelicopterRevival),
-
-			lockedBaseOrientation = baseEnt.orientation,
+  ------------------------------------------------------------
+
+  new = function(placementEnt, baseEnt, childEnts, mt)
+    transferGridEquipment(placementEnt, baseEnt)
+    baseEnt.health = placementEnt.health
+
+    local obj = {
+      version = versionStrToInt(game.active_mods.HelicopterRevival),
+
+      lockedBaseOrientation = baseEnt.orientation,
 
-			baseEnt = baseEnt,
-			childs = childEnts,
-
-			surface = placementEnt.surface,
+      baseEnt = baseEnt,
+      childs = childEnts,
+
+      surface = placementEnt.surface,
 
-			deactivatedInserters = {},
-		}
-
-		placementEnt.destroy()
-
-		obj.baseEnt.effectivity_modifier = 0
-
-		for k,v in pairs(obj.childs) do
-			if game.active_mods["Krastorio2"] then --Krastorio 2 workaround
-				v.get_inventory(defines.inventory.fuel).insert({name = "fuel", count = 200})
-			elseif game.active_mods["SeaBlock"] then --SeaBlock workaround
-				v.get_inventory(defines.inventory.fuel).insert({name = "cellulose-fiber", count = 200})
-			else
-				v.get_inventory(defines.inventory.fuel).insert({name = "coal", count = 50})
-			end
-			v.destructible = false
-		end
-
-		setmetatable(obj, mt)
-		obj:changeState(obj.landed)
-
-		return obj
-	end,
+      deactivatedInserters = {},
+    }
+
+    placementEnt.destroy()
+
+    obj.baseEnt.effectivity_modifier = 0
+
+    for k,v in pairs(obj.childs) do
+      if game.active_mods["Krastorio2"] then --Krastorio 2 workaround
+        v.get_inventory(defines.inventory.fuel).insert({name = "fuel", count = 200})
+      elseif game.active_mods["SeaBlock"] then --SeaBlock workaround
+        v.get_inventory(defines.inventory.fuel).insert({name = "cellulose-fiber", count = 200})
+      else
+        v.get_inventory(defines.inventory.fuel).insert({name = "coal", count = 50})
+      end
+      v.destructible = false
+    end
+
+    setmetatable(obj, mt)
+    obj:changeState(obj.landed)
+
+    return obj
+  end,
 
-	destroy = function(self)
-		self.valid = false
+  destroy = function(self)
+    self.valid = false
 
-		if self.baseEnt and self.baseEnt.valid then
-			--self.baseEnt.destroy()
-		end
+    if self.baseEnt and self.baseEnt.valid then
+      --self.baseEnt.destroy()
+    end
 
-		for k,v in pairs(self.childs) do
-			if v and v.valid then
-				v.destroy()
-			end
-		end
+    for k,v in pairs(self.childs) do
+      if v and v.valid then
+        v.destroy()
+      end
+    end
 
-		if self.burnerDriver and self.burnerDriver.valid then
-			self.burnerDriver.destroy()
-		end
-		if self.floodlightDriver and self.floodlightDriver.valid then
-			self.floodlightDriver.destroy()
-		end
+    if self.burnerDriver and self.burnerDriver.valid then
+      self.burnerDriver.destroy()
+    end
+    if self.floodlightDriver and self.floodlightDriver.valid then
+      self.floodlightDriver.destroy()
+    end
 
-		self:reactivateAllInserters()
-
-		for k, curGG in pairs(self.gaugeGuis) do
-			curGG:destroy()
-		end
-	end,
-
-	---------------- events ----------------
-
-	OnLoad = function(self)
-		if self.curState then
-			setmetatable(self.curState, basicState.mt)
-		end
-		if self.previousState then
-			setmetatable(self.previousState, basicState.mt)
-		end
-		if self.hasLandedCollider and self.childs.collisionEnt then
-			setmetatable(self.childs.collisionEnt, emptyBoxCollider.mt)
-		end
-	end,
-
-	OnTick = function(self)
-		if not self.baseEnt.valid or (self.childs.collisionEnt and not self.childs.collisionEnt.valid) then
-			self:destroy() --Destroy child entities first
-			if self.baseEnt and self.baseEnt.valid then
-				self.baseEnt.destroy() --Re-check if the base entity is also valid, and destroy that as well
-			end
-			return
-		end
-
-		self:redirectPassengers()
-		self:updateRotor()
-		self:updateHeight()
-		self:updateFuelGauge()
-		self:updateEntityPositions()
-		self.curState.OnTick(self)
-
-		if self.valid then
-			self:handleColliderDamage()
-		end
-	end,
-
-	OnUp = function(self)
-		self.curState.OnUp(self)
-	end,
-
-	OnDown = function(self)
-		self:changeState(self.descend)
-	end,
-
-	OnIncreaseMaxHeight = function(self)
-		self.maxHeight = math.min(self.maxHeightUperLimit, self.maxHeight + 1)
-		self.curState.OnMaxHeightChanged(self)
-	end,
-
-	OnDecreaseMaxHeight = function(self)
-		self.maxHeight = math.max(self.maxHeightLowerLimit, self.maxHeight - 1)
-		self.curState.OnMaxHeightChanged(self)
-	end,
-
-	OnToggleFloodlight = function(self)
-		self.floodlightEnabled = not self.floodlightEnabled
-
-		if not self.floodlightEnabled then
-			self:setFloodlightEntities(false)
-
-		elseif self.height ~= 0 or self.rotorTargetRPF > 0 then
-			self:setFloodlightEntities(true)
-		end
-	end,
-
-	OnPlayerEjected = function(self)
-		if self.childs.collisionEnt and self.hasLandedCollider then
-			self.childs.collisionEnt.ejectPlayers()
-		end
-	end,
-
-
-	---------------- states ----------------
-
-	landed = basicState.new({
-		name = "landed",
-	}),
-
-	engineStarting = basicState.new({
-		name = "engineStarting",
-	}),
-
-	ascend = basicState.new({
-		name = "ascend",
-	}),
-
-	hovering = basicState.new({
-		name = "hovering",
-	}),
-
-	descend = basicState.new({
-		name = "descend",
-	}),
-
-	engineStopping = basicState.new({
-		name = "engineStopping",
-	}),
-
-
-	---------------- utility ---------------
-
-	reactivateAllInserters = function(self)
-		for k, curInserter in pairs(self.deactivatedInserters) do
-			if curInserter.valid then
-				curInserter.active = true
-			end
-		end
-
-		self.deactivatedInserters = {}
-	end,
-
-	reactivateSafeInserters = function(self)
-		for i = #self.deactivatedInserters, 1, -1 do
-			local curInserter = self.deactivatedInserters[i]
-
-			if not curInserter.valid then
-				table.remove(self.deactivatedInserters, i)
-
-			elseif getDistance(curInserter.position, self.baseEnt.position) > self.inserterScanRadius then
-				curInserter.active = true
-				table.remove(self.deactivatedInserters, i)
-			end
-		end
-	end,
-
-	deactivateNearbyInserters = function(self)
-		local p = self.baseEnt.position
-		local area = {{p.x - self.inserterScanRadius, p.y - self.inserterScanRadius}, {p.x + self.inserterScanRadius, p.y + self.inserterScanRadius}}
-
-		local inserters = self.surface.find_entities_filtered{
-			type = "inserter",
-			area = area,
-		}
-
-		for k, curInserter in pairs(inserters) do
-			if curInserter.active then
-				curInserter.active = false
-				table.insert(self.deactivatedInserters, curInserter)
-			end
-		end
-	end,
-
-	handleInserters = function(self)
-		if settings.global["heli-deactivate-inserters"].value then
-			self:deactivateNearbyInserters()
-			self:reactivateSafeInserters()
-
-		elseif #self.deactivatedInserters > 0 then
-			self:reactivateAllInserters()
-		end
-	end,
-
-	setTargetHeight = function(self, targetHeight)
-		self.targetHeight = targetHeight
-		return 60
-	end,
-
-	setRotorTargetRPF = function(self, targetRPF)
-		self.rotorTargetRPF = targetRPF
-	end,
-
-	setFuelGaugeTarget = function(self, targetFuel, suppressAlert)
-		self.fuelGaugeTargetVal = targetFuel
-
-		if not suppressAlert then
-			local alert
-			if self.fuelGaugeTargetVal <= self.tankCriticalWarningRatio and self.lastFuelGaugeTargetVal > self.tankCriticalWarningRatio then
-				alert = {name = "signal-heli-fuel-warning-critical", str = {"heli-alert-fuel-warning-critical"}}
-
-			elseif self.fuelGaugeTargetVal <= self.tankWarningRatio and self.lastFuelGaugeTargetVal > self.tankWarningRatio then
-				alert = {name = "signal-heli-fuel-warning", str = {"heli-alert-fuel-warning"}}
-			end
-
-			if alert then
-				local players = getCarPlayers(self.baseEnt)
-				for k, curPlayer in pairs(players) do
-					if curPlayer.mod_settings["heli-fuel-alert"].value then
-						curPlayer.add_custom_alert(self.baseEnt, {type = "virtual", name = alert.name}, alert.str, false)
-					end
-				end
-			end
-		end
-		self.lastFuelGaugeTargetVal = self.fuelGaugeTargetVal
-	end,
-
-	changeHeight = function(self, newHeight)
-		local delta = newHeight - self.height
-		local oldY = self.baseEnt.position.y
-
-		self.baseEnt.teleport({x = self.baseEnt.position.x, y = self.baseEnt.position.y - delta})
-
-
-		if newHeight == self.targetHeight then
-			self.height = self.targetHeight
-
-		else
-			--cant just apply the delta, the height would not reflect the sum of teleports,
-			--causing the shadow to move down.
-			--probably because of precision loss from lua->c++ / double->float
-			self.height = self.height + oldY - self.baseEnt.position.y
-		end
-	end,
-
-	landIfEmpty = function(self)
-		local driver = self.baseEnt.get_driver()
-		if not driver or not driver.valid or IsEntityBurnerOutOfFuel(self.baseEnt) then
-			self:OnDown()
-		end
-	end,
-
-	reassignCurState = function(self)
-		if self.curState then
-			local s = self[self.curState.name]
-
-			if s and type(s) == "table" and s.name == self.curState.name then
-				self.curState = s
-			end
-		end
-	end,
-
-	changeState = function(self, newState)
-		--[[
-		for k,v in pairs(heli) do
-			if v == newState then
-				printA("change state: " .. k)
-				break
-			end
-		end
-		]]
-
-		self.previousState = self.curState
-
-		if self.curState and self.curState.deinit then
-			self.curState.deinit(self)
-		end
-
-		self.curState = newState
-
-		if self.curState.init then
-			self.curState.init(self)
-		end
-	end,
-
-	insertIntoCar = function(self, car, player)
-		if car and car.valid and player and player.valid then
-			if not car.get_driver() then
-				car.set_driver(player)
-				return true
-			end
-
-			if not car.get_passenger() then
-				car.set_passenger(player)
-				return true
-			end
-
-			return false
-		end
-	end,
-
-	redirectPassengers = function(self)
-		for k, curChild in pairs(self.childs) do
-			if curChild and curChild.valid then
-				local curDriver = curChild.get_driver()
-				local curPassenger = curChild.get_passenger()
-
-				if curDriver and curDriver.valid then
-					if k == "burnerEnt" and self.burnerDriver then
-						if curDriver ~= self.burnerDriver then
-							self:insertIntoCar(self.baseEnt, curDriver)
-							curChild.set_driver(self.burnerDriver)
-						end
-
-					elseif k == "floodlightEnt" and self.floodlightDriver then
-						if curDriver ~= self.floodlightDriver then
-							self:insertIntoCar(self.baseEnt, curDriver)
-							curChild.set_driver(self.floodlightDriver)
-						end
-
-					else
-						if not self:insertIntoCar(self.baseEnt, curDriver) then
-							curChild.set_driver(nil)
-						end
-					end
-				end
-
-				if curPassenger and curPassenger.valid then
-					if not self:insertIntoCar(self.baseEnt, curPassenger) then
-						curChild.set_passenger(nil)
-					end
-				end
-			end
-		end
-	end,
-
-	setCollider = function(self, name)
-		if self.childs.collisionEnt and self.childs.collisionEnt.valid then
-			self.childs.collisionEnt.destroy()
-			self.childs.collisionEnt = nil
-			self.hasLandedCollider = false
-		end
-
-		if name == "landed" then
-			self.childs.collisionEnt = emptyBoxCollider.new({
-				surface = self.surface,
-				position = self.baseEnt.position,
-				orientation = self.baseEnt.orientation,
-				force = game.forces.neutral,
-				boxLengths =
-				{
-					ends = 3,
-					sides = 4.8,
-				},
-				nameEnds = "heli-landed-collision-end-entity-_-",
-				nameSides = "heli-landed-collision-side-entity-_-",
-			})
-
-			self.childs.collisionEnt.ejectPlayers()
-			self.hasLandedCollider = true
-
-		elseif name == "flying" then
-			self.childs.collisionEnt = self.surface.create_entity{
-				name = "heli-flying-collision-entity-_-",
-				force = game.forces.neutral,
-				position = self.baseEnt.position,
-			}
-		end
-
-		if self.childs.collisionEnt then
-			if game.active_mods["Krastorio2"] then --Krastorio 2 workaround
-				self.childs.collisionEnt.get_inventory(defines.inventory.fuel).insert({name = "fuel", count = 200})
-			elseif game.active_mods["SeaBlock"] then --SeaBlock workaround
-				self.childs.collisionEnt.get_inventory(defines.inventory.fuel).insert({name = "cellulose-fiber", count = 200})
-			else
-				self.childs.collisionEnt.get_inventory(defines.inventory.fuel).insert({name = "coal", count = 50})
-			end
-			self.childs.collisionEnt.operable = false
-		end
-	end,
-
-	setFloodlightEntities = function(self, enabled)
-		if enabled then
-			if not (self.childs.floodlightEnt and self.childs.floodlightEnt.valid) then
-				self.childs.floodlightEnt = self.surface.create_entity{name = "heli-floodlight-entity-_-", force = game.forces.neutral, position = self.baseEnt.position}
-				if game.active_mods["Krastorio2"] then --Krastorio 2 workaround
-					self.childs.floodlightEnt.get_inventory(defines.inventory.fuel).insert({name = "fuel", count = 200})
-				elseif game.active_mods["SeaBlock"] then --SeaBlock workaround
-					self.childs.collisionEnt.get_inventory(defines.inventory.fuel).insert({name = "cellulose-fiber", count = 200})
-				else
-					self.childs.floodlightEnt.get_inventory(defines.inventory.fuel).insert({name = "coal", count = 50})
-				end
-			end
-			self.childs.floodlightEnt.orientation = self.baseEnt.orientation
-			self.childs.floodlightEnt.operable = false
-
-			if not (self.floodlightDriver and self.floodlightDriver.valid) then
-				self.floodlightDriver = self.surface.create_entity{name="character", force = game.forces.neutral, position = self.baseEnt.position}
-			end
-
-			self.childs.floodlightEnt.set_driver(self.floodlightDriver)
-		else
-
-			if self.childs.floodlightEnt and self.childs.floodlightEnt.valid then
-				self.childs.floodlightEnt.destroy()
-			end
-			self.childs.floodlightEnt = nil
-
-			if self.floodlightDriver and self.floodlightDriver.valid then
-				self.floodlightDriver.destroy()
-			end
-			self.floodlightDriver = nil
-		end
-	end,
-
-	dealCrashDamage = function(self, players, speed)
-		for k, curPlayer in pairs(players) do
-			if curPlayer.character and curPlayer.character.valid then
-				curPlayer.character.damage((150 + speed * 175) * settings.global["heli-crash-dmg-mult"].value, game.forces.neutral)
-			end
-		end
-	end,
-
-	handleColliderDamage = function(self)
-		if self.childs.collisionEnt then
-			if self.childs.collisionEnt.health ~= colliderMaxHealth then
-				local players = getCarPlayers(self.baseEnt)
-				local speed = self.childs.collisionEnt.speed
-
-				self.baseEnt.speed = speed
-				self.baseEnt.damage(colliderMaxHealth - self.childs.collisionEnt.health, game.forces.neutral)
-
-				if not self.baseEnt.valid then --destroy event might already be executed
-					self:dealCrashDamage(players, speed)
-
-					return false
-				end
-				self.childs.collisionEnt.health = colliderMaxHealth
-			end
-		end
-		return true
-	end,
-
-	getFuelFullness = function(self)
-		local remainingFuel = self.baseEnt.burner.remaining_burning_fuel
-		local bbInv = self.baseEnt.burner.inventory
-
-		for i = 1, #bbInv do
-			local curStack = bbInv[i]
-
-			if curStack and curStack.valid_for_read then
-				remainingFuel = remainingFuel + curStack.count * curStack.prototype.fuel_value
-			end
-		end
-
-		if game.active_mods["Krastorio2"] then
-			remainingFuel = remainingFuel * 16
-		elseif game.active_mods["SeaBlock"] then
-			remainingFuel = remainingFuel * 9
-		end
-
-		local burner = self.baseEnt.burner
-		local full_value = 0
-		if burner.currently_burning then
-			full_value = burner.currently_burning.fuel_value * burner.currently_burning.stack_size * #burner.inventory
-		end
-		if full_value > 0 then
-			return remainingFuel / full_value
-		else
-			return 0
-		end
-	end,
-
-	handleFuelConsumption = function(self)
-		self:consumeBaseFuel()
-		self:setFuelGaugeTarget(self:getFuelFullness())
-	end,
-
-	consumeBaseFuel = function(self)
-
-		local baseBurner = self.baseEnt.burner
-
-		baseBurner.remaining_burning_fuel = baseBurner.remaining_burning_fuel - self.baseEngineConsumption
-
-		if baseBurner.remaining_burning_fuel <= 0 then
-			if baseBurner.inventory.is_empty() then
-				local mod = self.baseEnt.effectivity_modifier
-				self.baseEnt.effectivity_modifier = 0
-
-				local driver = self.baseEnt.get_driver()
-				if driver and driver.valid then
-					driver.riding_state = {acceleration = defines.riding.acceleration.accelerating, direction = defines.riding.direction.straight}
-
-				else
-					driver = self.surface.create_entity{name = "character", force = self.baseEnt.force, position = self.baseEnt.position}
-					self.baseEnt.set_driver(driver)
-					driver.riding_state = {acceleration = defines.riding.acceleration.accelerating, direction = defines.riding.direction.straight}
-					driver.destroy()
-					self.baseEnt.set_driver(nil)
-				end
-
-				self.baseEnt.effectivity_modifier = mod
-			else
-				local fuelItemStack = nil
-				for i = 1, #baseBurner.inventory do
-					if baseBurner.inventory[i] and baseBurner.inventory[i].valid_for_read then
-						fuelItemStack = baseBurner.inventory[i]
-						break
-					end
-				end
-
-				if fuelItemStack then
-					baseBurner.currently_burning = fuelItemStack.name
-					baseBurner.remaining_burning_fuel = fuelItemStack.prototype.fuel_value
-					baseBurner.inventory.remove({name = fuelItemStack.name})
-				end
-			end
-		end
-
-		if self.burnerDriver and self.burnerDriver.valid then
-			self.burnerDriver.riding_state = {acceleration = defines.riding.acceleration.accelerating, direction = defines.riding.direction.straight}
-			if self.childs.burnerEnt.burner.remaining_burning_fuel < 1000 then
-				if game.active_mods["Krastorio2"] then --Krastorio 2 workaround
-					self.childs.burnerEnt.get_inventory(defines.inventory.fuel).insert({name = "fuel", count = 1})
-				elseif game.active_mods["SeaBlock"] then --SeaBlock workaround
-					self.childs.burnerEnt.get_inventory(defines.inventory.fuel).insert({name = "cellulose-fiber", count = 1})
-				else
-					self.childs.burnerEnt.get_inventory(defines.inventory.fuel).insert({name = "coal", count = 1})
-				end
-			end
-		end
-	end,
-
-	updateRotor = function(self)
-		if self.rotorRPF ~= self.rotorTargetRPF then
-			if self.rotorRPF < self.rotorTargetRPF then
-				self.rotorRPF = math.min(self.rotorRPF + self.rotorRPFacceleration, self.rotorTargetRPF)
-
-			else
-				self.rotorRPF = math.max(self.rotorRPF - self.rotorRPFacceleration, self.rotorTargetRPF)
-			end
-		end
-
-		if self.rotorRPF > 0 then
-			self.rotorOrient = self.rotorOrient + self.rotorRPF
-			if self.rotorOrient > 1 then self.rotorOrient = self.rotorOrient - 1 end
-
-			local frameFix = frameFixes[math.floor(self.rotorOrient * 64) + 1]
-			self.childs.rotorEnt.orientation = frameFix
-			self.childs.rotorEntShadow.orientation = frameFix
-		end
-
-
-		for k, curGG in pairs(self.gaugeGuis) do
-			curGG:setGauge("gauge_hr", "rpm", self.rotorRPF * 3600 * self.engineReduction + math.abs(self.baseEnt.speed) * 100)
-		end
-	end,
-
-	updateHeight = function(self)
-		if self.height ~= self.targetHeight then
-			local dir = 1
-			if self.targetHeight < self.height then
-				dir = -1
-			end
-
-			local desiredSpeed = (self.targetHeight - self.height) / 90 + dir * 0.005
-
-			if self.heightSpeed < desiredSpeed then
-				self.heightSpeed = math.min(self.heightSpeed + self.heightAcceleration, desiredSpeed)
-			else
-				self.heightSpeed = math.max(self.heightSpeed - self.heightAcceleration, desiredSpeed)
-			end
-
-			local newHeight = self.height + self.heightSpeed
-
-			if fEqual(newHeight, self.targetHeight, 0.01) then
-				self:changeHeight(self.targetHeight)
-				self.heightSpeed = 0
-			else
-				self:changeHeight(newHeight)
-			end
-		end
-
-		for k, curGG in pairs(self.gaugeGuis) do
-			curGG:setGauge("gauge_hr", "height", self.height)
-		end
-	end,
-
-	updateFuelGauge = function(self)
-		if self.fuelGaugeVal ~= self.fuelGaugeTargetVal then
-			if self.fuelGaugeVal < self.fuelGaugeTargetVal then
-				self.fuelGaugeVal = math.min(self.fuelGaugeVal + self.fuelGaugeSpeed, self.fuelGaugeTargetVal)
-
-			else
-				self.fuelGaugeVal = math.max(self.fuelGaugeVal - self.fuelGaugeSpeed, self.fuelGaugeTargetVal)
-			end
-		end
-
-		for k, curGG in pairs(self.gaugeGuis) do
-			curGG:setGauge("gauge_fs", "fuel", self.fuelGaugeVal)
-			if self.curState.name ~= "landed" then
-				if self.fuelGaugeTargetVal <= self.tankCriticalWarningRatio then
-					curGG:setLedBlinking("gauge_fs", "fuel", true, 20, "heli-fuel-warning")
-
-				elseif self.fuelGaugeTargetVal <= self.tankWarningRatio then
-					curGG:setLedBlinking("gauge_fs", "fuel", true, 60, "heli-fuel-warning")
-
-				else
-					curGG:setLedBlinking("gauge_fs", "fuel", false)
-				end
-			else
-				curGG:setLedBlinking("gauge_fs", "fuel", false)
-			end
-		end
-	end,
-
-	updateEntityPositions = function(self)
-		local baseVec = math3d.vector2.rotate({0,1}, math.pi * 2 * self.baseEnt.orientation)
-		local vec = math3d.vector2.mul(baseVec, self.baseEnt.speed)
-
-		local basePos = self.baseEnt.position
-
-		self.childs.bodyEnt.teleport({x = basePos.x - vec[1], y = basePos.y - vec[2] + self.bodyOffset - self.curBobbing})
-		self.childs.rotorEnt.teleport({x = basePos.x - vec[1], y = basePos.y - vec[2] + self.rotorOffset - self.curBobbing})
-
-		self.childs.rotorEntShadow.teleport({x = basePos.x - vec[1], y = basePos.y - vec[2] +self.height})
-		self.childs.bodyEntShadow.teleport({x = basePos.x - vec[1], y = basePos.y - vec[2] + self.height})
-
-		if self.childs.floodlightEnt then
-			local lightOffsetVec = math3d.vector2.mul(baseVec, self.height)
-			self.childs.floodlightEnt.teleport({x = basePos.x - vec[1] - lightOffsetVec[1], y = basePos.y - vec[2] - lightOffsetVec[2] + self.height})
-		end
-
-		if self.childs.collisionEnt then
-			if not self.hasLandedCollider then
-				local initVec = {0,1}
-				local mul = 2
-				if self.baseEnt.speed < 0 then
-					initVec = {0,-1}
-					local x = self.baseEnt.orientation
-					mul = math.abs(math.sin(math.pi*2*x))*1.2 + math.sin(math.pi*x) + 3 --dont ask
-				end
-
-				vec = math3d.vector2.mul(math3d.vector2.rotate(initVec, math.pi * 2 * self.baseEnt.orientation), mul)
-				self.childs.collisionEnt.teleport({x = basePos.x - vec[1], y = basePos.y - vec[2]})
-				self.childs.collisionEnt.speed = self.baseEnt.speed
-
-			else
-				self.childs.collisionEnt.teleport({x = basePos.x - vec[1], y = basePos.y - vec[2]})
-				self.childs.collisionEnt.speed = self.baseEnt.speed
-			end
-		end
-
-
-		local off = (1 - math.sin(math.pi*self.baseEnt.orientation)) * 0.7
-		local center = {x = basePos.x, y = basePos.y - off}
-		local radius = 2
-		snap = self.baseEnt.orientation
-		snap = snap * (1 - math.sin(math.pi * snap)*0.05)
-		snap = math.abs(snap * 64) / 64
-		local vec = math3d.vector2.mul(math3d.vector2.rotate({0,1}, math.pi * 2 * snap), radius)
-
-		self.childs.burnerEnt.teleport({x = center.x + vec[1], y = center.y + vec[2] - self.curBobbing})
-
-		for k, curGG in pairs(self.gaugeGuis) do
-			curGG:setGauge("gauge_fs", "speed", math.abs(self.baseEnt.speed) * 216) --speed * 60 = m/s, * 3.6 = km/h
-		end
-	end,
-
-	updateEntityRotations = function(self)
-		self.childs.bodyEnt.orientation = self.baseEnt.orientation
-		self.childs.bodyEntShadow.orientation = self.baseEnt.orientation
-		self.childs.burnerEnt.orientation = self.baseEnt.orientation
-
-		if self.childs.collisionEnt then
-			self.childs.collisionEnt.orientation = self.baseEnt.orientation
-		end
-
-		if self.childs.floodlightEnt then
-			self.childs.floodlightEnt.orientation = self.baseEnt.orientation
-		end
-	end,
-
-	isBaseOrChild = function(self, ent)
-		if self.baseEnt == ent then
-			return true
-		end
-
-		for k,v in pairs(self.childs) do
-			if v == ent then
-				return true
-			end
-		end
-
-		if self.hasLandedCollider and self.childs.collisionEnt then
-			return self.childs.collisionEnt.isChildEntity(ent)
-		end
-
-		return false
-	end,
-
-	addGaugeGui = function(self, gg)
-		if #self.gaugeGuis == 0 then
-			self.gaugeGuis = {}
-		end
-
-		table.insert(self.gaugeGuis, gg)
-	end,
-
-	removeGaugeGui = function(self, gg)
-		for i, curGG in ipairs(self.gaugeGuis) do
-			if curGG == gg then
-				table.remove(self.gaugeGuis, i)
-				return
-			end
-		end
-	end,
+    self:reactivateAllInserters()
+
+    for k, curGG in pairs(self.gaugeGuis) do
+      curGG:destroy()
+    end
+  end,
+
+  ---------------- events ----------------
+
+  OnLoad = function(self)
+    if self.curState then
+      setmetatable(self.curState, basicState.mt)
+    end
+    if self.previousState then
+      setmetatable(self.previousState, basicState.mt)
+    end
+    if self.hasLandedCollider and self.childs.collisionEnt then
+      setmetatable(self.childs.collisionEnt, emptyBoxCollider.mt)
+    end
+  end,
+
+  OnTick = function(self)
+    if not self.baseEnt.valid or (self.childs.collisionEnt and not self.childs.collisionEnt.valid) then
+      self:destroy() --Destroy child entities first
+      if self.baseEnt and self.baseEnt.valid then
+        self.baseEnt.destroy() --Re-check if the base entity is also valid, and destroy that as well
+      end
+      return
+    end
+
+    self:redirectPassengers()
+    self:updateRotor()
+    self:updateHeight()
+    self:updateFuelGauge()
+    self:updateEntityPositions()
+    self.curState.OnTick(self)
+
+    if self.valid then
+      self:handleColliderDamage()
+    end
+  end,
+
+  OnUp = function(self)
+    self.curState.OnUp(self)
+  end,
+
+  OnDown = function(self)
+    self:changeState(self.descend)
+  end,
+
+  OnIncreaseMaxHeight = function(self)
+    self.maxHeight = math.min(self.maxHeightUperLimit, self.maxHeight + 1)
+    self.curState.OnMaxHeightChanged(self)
+  end,
+
+  OnDecreaseMaxHeight = function(self)
+    self.maxHeight = math.max(self.maxHeightLowerLimit, self.maxHeight - 1)
+    self.curState.OnMaxHeightChanged(self)
+  end,
+
+  OnToggleFloodlight = function(self)
+    self.floodlightEnabled = not self.floodlightEnabled
+
+    if not self.floodlightEnabled then
+      self:setFloodlightEntities(false)
+
+    elseif self.height ~= 0 or self.rotorTargetRPF > 0 then
+      self:setFloodlightEntities(true)
+    end
+  end,
+
+  OnPlayerEjected = function(self)
+    if self.childs.collisionEnt and self.hasLandedCollider then
+      self.childs.collisionEnt.ejectPlayers()
+    end
+  end,
+
+
+  ---------------- states ----------------
+
+  landed = basicState.new({
+    name = "landed",
+  }),
+
+  engineStarting = basicState.new({
+    name = "engineStarting",
+  }),
+
+  ascend = basicState.new({
+    name = "ascend",
+  }),
+
+  hovering = basicState.new({
+    name = "hovering",
+  }),
+
+  descend = basicState.new({
+    name = "descend",
+  }),
+
+  engineStopping = basicState.new({
+    name = "engineStopping",
+  }),
+
+
+  ---------------- utility ---------------
+
+  reactivateAllInserters = function(self)
+    for k, curInserter in pairs(self.deactivatedInserters) do
+      if curInserter.valid then
+        curInserter.active = true
+      end
+    end
+
+    self.deactivatedInserters = {}
+  end,
+
+  reactivateSafeInserters = function(self)
+    for i = #self.deactivatedInserters, 1, -1 do
+      local curInserter = self.deactivatedInserters[i]
+
+      if not curInserter.valid then
+        table.remove(self.deactivatedInserters, i)
+
+      elseif getDistance(curInserter.position, self.baseEnt.position) > self.inserterScanRadius then
+        curInserter.active = true
+        table.remove(self.deactivatedInserters, i)
+      end
+    end
+  end,
+
+  deactivateNearbyInserters = function(self)
+    local p = self.baseEnt.position
+    local area = {{p.x - self.inserterScanRadius, p.y - self.inserterScanRadius}, {p.x + self.inserterScanRadius, p.y + self.inserterScanRadius}}
+
+    local inserters = self.surface.find_entities_filtered{
+      type = "inserter",
+      area = area,
+    }
+
+    for k, curInserter in pairs(inserters) do
+      if curInserter.active then
+        curInserter.active = false
+        table.insert(self.deactivatedInserters, curInserter)
+      end
+    end
+  end,
+
+  handleInserters = function(self)
+    if settings.global["heli-deactivate-inserters"].value then
+      self:deactivateNearbyInserters()
+      self:reactivateSafeInserters()
+
+    elseif #self.deactivatedInserters > 0 then
+      self:reactivateAllInserters()
+    end
+  end,
+
+  setTargetHeight = function(self, targetHeight)
+    self.targetHeight = targetHeight
+    return 60
+  end,
+
+  setRotorTargetRPF = function(self, targetRPF)
+    self.rotorTargetRPF = targetRPF
+  end,
+
+  setFuelGaugeTarget = function(self, targetFuel, suppressAlert)
+    self.fuelGaugeTargetVal = targetFuel
+
+    if not suppressAlert then
+      local alert
+      if self.fuelGaugeTargetVal <= self.tankCriticalWarningRatio and self.lastFuelGaugeTargetVal > self.tankCriticalWarningRatio then
+        alert = {name = "signal-heli-fuel-warning-critical", str = {"heli-alert-fuel-warning-critical"}}
+
+      elseif self.fuelGaugeTargetVal <= self.tankWarningRatio and self.lastFuelGaugeTargetVal > self.tankWarningRatio then
+        alert = {name = "signal-heli-fuel-warning", str = {"heli-alert-fuel-warning"}}
+      end
+
+      if alert then
+        local players = getCarPlayers(self.baseEnt)
+        for k, curPlayer in pairs(players) do
+          if curPlayer.mod_settings["heli-fuel-alert"].value then
+            curPlayer.add_custom_alert(self.baseEnt, {type = "virtual", name = alert.name}, alert.str, false)
+          end
+        end
+      end
+    end
+    self.lastFuelGaugeTargetVal = self.fuelGaugeTargetVal
+  end,
+
+  changeHeight = function(self, newHeight)
+    local delta = newHeight - self.height
+    local oldY = self.baseEnt.position.y
+
+    self.baseEnt.teleport({x = self.baseEnt.position.x, y = self.baseEnt.position.y - delta})
+
+
+    if newHeight == self.targetHeight then
+      self.height = self.targetHeight
+
+    else
+      --cant just apply the delta, the height would not reflect the sum of teleports,
+      --causing the shadow to move down.
+      --probably because of precision loss from lua->c++ / double->float
+      self.height = self.height + oldY - self.baseEnt.position.y
+    end
+  end,
+
+  landIfEmpty = function(self)
+    local driver = self.baseEnt.get_driver()
+    if not driver or not driver.valid or IsEntityBurnerOutOfFuel(self.baseEnt) then
+      self:OnDown()
+    end
+  end,
+
+  reassignCurState = function(self)
+    if self.curState then
+      local s = self[self.curState.name]
+
+      if s and type(s) == "table" and s.name == self.curState.name then
+        self.curState = s
+      end
+    end
+  end,
+
+  changeState = function(self, newState)
+    --[[
+    for k,v in pairs(heli) do
+      if v == newState then
+        printA("change state: " .. k)
+        break
+      end
+    end
+    ]]
+
+    self.previousState = self.curState
+
+    if self.curState and self.curState.deinit then
+      self.curState.deinit(self)
+    end
+
+    self.curState = newState
+
+    if self.curState.init then
+      self.curState.init(self)
+    end
+  end,
+
+  insertIntoCar = function(self, car, player)
+    if car and car.valid and player and player.valid then
+      if not car.get_driver() then
+        car.set_driver(player)
+        return true
+      end
+
+      if not car.get_passenger() then
+        car.set_passenger(player)
+        return true
+      end
+
+      return false
+    end
+  end,
+
+  redirectPassengers = function(self)
+    for k, curChild in pairs(self.childs) do
+      if curChild and curChild.valid then
+        local curDriver = curChild.get_driver()
+        local curPassenger = curChild.get_passenger()
+
+        if curDriver and curDriver.valid then
+          if k == "burnerEnt" and self.burnerDriver then
+            if curDriver ~= self.burnerDriver then
+              self:insertIntoCar(self.baseEnt, curDriver)
+              curChild.set_driver(self.burnerDriver)
+            end
+
+          elseif k == "floodlightEnt" and self.floodlightDriver then
+            if curDriver ~= self.floodlightDriver then
+              self:insertIntoCar(self.baseEnt, curDriver)
+              curChild.set_driver(self.floodlightDriver)
+            end
+
+          else
+            if not self:insertIntoCar(self.baseEnt, curDriver) then
+              curChild.set_driver(nil)
+            end
+          end
+        end
+
+        if curPassenger and curPassenger.valid then
+          if not self:insertIntoCar(self.baseEnt, curPassenger) then
+            curChild.set_passenger(nil)
+          end
+        end
+      end
+    end
+  end,
+
+  setCollider = function(self, name)
+    if self.childs.collisionEnt and self.childs.collisionEnt.valid then
+      self.childs.collisionEnt.destroy()
+      self.childs.collisionEnt = nil
+      self.hasLandedCollider = false
+    end
+
+    if name == "landed" then
+      self.childs.collisionEnt = emptyBoxCollider.new({
+        surface = self.surface,
+        position = self.baseEnt.position,
+        orientation = self.baseEnt.orientation,
+        force = game.forces.neutral,
+        boxLengths =
+        {
+          ends = 3,
+          sides = 4.8,
+        },
+        nameEnds = "heli-landed-collision-end-entity-_-",
+        nameSides = "heli-landed-collision-side-entity-_-",
+      })
+
+      self.childs.collisionEnt.ejectPlayers()
+      self.hasLandedCollider = true
+
+    elseif name == "flying" then
+      self.childs.collisionEnt = self.surface.create_entity{
+        name = "heli-flying-collision-entity-_-",
+        force = game.forces.neutral,
+        position = self.baseEnt.position,
+      }
+    end
+
+    if self.childs.collisionEnt then
+      if game.active_mods["Krastorio2"] then --Krastorio 2 workaround
+        self.childs.collisionEnt.get_inventory(defines.inventory.fuel).insert({name = "fuel", count = 200})
+      elseif game.active_mods["SeaBlock"] then --SeaBlock workaround
+        self.childs.collisionEnt.get_inventory(defines.inventory.fuel).insert({name = "cellulose-fiber", count = 200})
+      else
+        self.childs.collisionEnt.get_inventory(defines.inventory.fuel).insert({name = "coal", count = 50})
+      end
+      self.childs.collisionEnt.operable = false
+    end
+  end,
+
+  setFloodlightEntities = function(self, enabled)
+    if enabled then
+      if not (self.childs.floodlightEnt and self.childs.floodlightEnt.valid) then
+        self.childs.floodlightEnt = self.surface.create_entity{name = "heli-floodlight-entity-_-", force = game.forces.neutral, position = self.baseEnt.position}
+        if game.active_mods["Krastorio2"] then --Krastorio 2 workaround
+          self.childs.floodlightEnt.get_inventory(defines.inventory.fuel).insert({name = "fuel", count = 200})
+        elseif game.active_mods["SeaBlock"] then --SeaBlock workaround
+          self.childs.collisionEnt.get_inventory(defines.inventory.fuel).insert({name = "cellulose-fiber", count = 200})
+        else
+          self.childs.floodlightEnt.get_inventory(defines.inventory.fuel).insert({name = "coal", count = 50})
+        end
+      end
+      self.childs.floodlightEnt.orientation = self.baseEnt.orientation
+      self.childs.floodlightEnt.operable = false
+
+      if not (self.floodlightDriver and self.floodlightDriver.valid) then
+        self.floodlightDriver = self.surface.create_entity{name="character", force = game.forces.neutral, position = self.baseEnt.position}
+      end
+
+      self.childs.floodlightEnt.set_driver(self.floodlightDriver)
+    else
+
+      if self.childs.floodlightEnt and self.childs.floodlightEnt.valid then
+        self.childs.floodlightEnt.destroy()
+      end
+      self.childs.floodlightEnt = nil
+
+      if self.floodlightDriver and self.floodlightDriver.valid then
+        self.floodlightDriver.destroy()
+      end
+      self.floodlightDriver = nil
+    end
+  end,
+
+  dealCrashDamage = function(self, players, speed)
+    for k, curPlayer in pairs(players) do
+      if curPlayer.character and curPlayer.character.valid then
+        curPlayer.character.damage((150 + speed * 175) * settings.global["heli-crash-dmg-mult"].value, game.forces.neutral)
+      end
+    end
+  end,
+
+  handleColliderDamage = function(self)
+    if self.childs.collisionEnt then
+      if self.childs.collisionEnt.health ~= colliderMaxHealth then
+        local players = getCarPlayers(self.baseEnt)
+        local speed = self.childs.collisionEnt.speed
+
+        self.baseEnt.speed = speed
+        self.baseEnt.damage(colliderMaxHealth - self.childs.collisionEnt.health, game.forces.neutral)
+
+        if not self.baseEnt.valid then --destroy event might already be executed
+          self:dealCrashDamage(players, speed)
+
+          return false
+        end
+        self.childs.collisionEnt.health = colliderMaxHealth
+      end
+    end
+    return true
+  end,
+
+  getFuelFullness = function(self)
+    local remainingFuel = self.baseEnt.burner.remaining_burning_fuel
+    local bbInv = self.baseEnt.burner.inventory
+
+    for i = 1, #bbInv do
+      local curStack = bbInv[i]
+
+      if curStack and curStack.valid_for_read then
+        remainingFuel = remainingFuel + curStack.count * curStack.prototype.fuel_value
+      end
+    end
+
+    if game.active_mods["Krastorio2"] then
+      remainingFuel = remainingFuel * 16
+    elseif game.active_mods["SeaBlock"] then
+      remainingFuel = remainingFuel * 9
+    end
+
+    local burner = self.baseEnt.burner
+    local full_value = 0
+    if burner.currently_burning then
+      full_value = burner.currently_burning.fuel_value * burner.currently_burning.stack_size * #burner.inventory
+    end
+    if full_value > 0 then
+      return remainingFuel / full_value
+    else
+      return 0
+    end
+  end,
+
+  handleFuelConsumption = function(self)
+    self:consumeBaseFuel()
+    self:setFuelGaugeTarget(self:getFuelFullness())
+  end,
+
+  consumeBaseFuel = function(self)
+
+    local baseBurner = self.baseEnt.burner
+
+    baseBurner.remaining_burning_fuel = baseBurner.remaining_burning_fuel - self.baseEngineConsumption
+
+    if baseBurner.remaining_burning_fuel <= 0 then
+      if baseBurner.inventory.is_empty() then
+        local mod = self.baseEnt.effectivity_modifier
+        self.baseEnt.effectivity_modifier = 0
+
+        local driver = self.baseEnt.get_driver()
+        if driver and driver.valid then
+          driver.riding_state = {acceleration = defines.riding.acceleration.accelerating, direction = defines.riding.direction.straight}
+
+        else
+          driver = self.surface.create_entity{name = "character", force = self.baseEnt.force, position = self.baseEnt.position}
+          self.baseEnt.set_driver(driver)
+          driver.riding_state = {acceleration = defines.riding.acceleration.accelerating, direction = defines.riding.direction.straight}
+          driver.destroy()
+          self.baseEnt.set_driver(nil)
+        end
+
+        self.baseEnt.effectivity_modifier = mod
+      else
+        local fuelItemStack = nil
+        for i = 1, #baseBurner.inventory do
+          if baseBurner.inventory[i] and baseBurner.inventory[i].valid_for_read then
+            fuelItemStack = baseBurner.inventory[i]
+            break
+          end
+        end
+
+        if fuelItemStack then
+          baseBurner.currently_burning = fuelItemStack.name
+          baseBurner.remaining_burning_fuel = fuelItemStack.prototype.fuel_value
+          baseBurner.inventory.remove({name = fuelItemStack.name})
+        end
+      end
+    end
+
+    if self.burnerDriver and self.burnerDriver.valid then
+      self.burnerDriver.riding_state = {acceleration = defines.riding.acceleration.accelerating, direction = defines.riding.direction.straight}
+      if self.childs.burnerEnt.burner.remaining_burning_fuel < 1000 then
+        if game.active_mods["Krastorio2"] then --Krastorio 2 workaround
+          self.childs.burnerEnt.get_inventory(defines.inventory.fuel).insert({name = "fuel", count = 1})
+        elseif game.active_mods["SeaBlock"] then --SeaBlock workaround
+          self.childs.burnerEnt.get_inventory(defines.inventory.fuel).insert({name = "cellulose-fiber", count = 1})
+        else
+          self.childs.burnerEnt.get_inventory(defines.inventory.fuel).insert({name = "coal", count = 1})
+        end
+      end
+    end
+  end,
+
+  updateRotor = function(self)
+    if self.rotorRPF ~= self.rotorTargetRPF then
+      if self.rotorRPF < self.rotorTargetRPF then
+        self.rotorRPF = math.min(self.rotorRPF + self.rotorRPFacceleration, self.rotorTargetRPF)
+
+      else
+        self.rotorRPF = math.max(self.rotorRPF - self.rotorRPFacceleration, self.rotorTargetRPF)
+      end
+    end
+
+    if self.rotorRPF > 0 then
+      self.rotorOrient = self.rotorOrient + self.rotorRPF
+      if self.rotorOrient > 1 then self.rotorOrient = self.rotorOrient - 1 end
+
+      local frameFix = frameFixes[math.floor(self.rotorOrient * 64) + 1]
+      self.childs.rotorEnt.orientation = frameFix
+      self.childs.rotorEntShadow.orientation = frameFix
+    end
+
+
+    for k, curGG in pairs(self.gaugeGuis) do
+      curGG:setGauge("gauge_hr", "rpm", self.rotorRPF * 3600 * self.engineReduction + math.abs(self.baseEnt.speed) * 100)
+    end
+  end,
+
+  updateHeight = function(self)
+    if self.height ~= self.targetHeight then
+      local dir = 1
+      if self.targetHeight < self.height then
+        dir = -1
+      end
+
+      local desiredSpeed = (self.targetHeight - self.height) / 90 + dir * 0.005
+
+      if self.heightSpeed < desiredSpeed then
+        self.heightSpeed = math.min(self.heightSpeed + self.heightAcceleration, desiredSpeed)
+      else
+        self.heightSpeed = math.max(self.heightSpeed - self.heightAcceleration, desiredSpeed)
+      end
+
+      local newHeight = self.height + self.heightSpeed
+
+      if fEqual(newHeight, self.targetHeight, 0.01) then
+        self:changeHeight(self.targetHeight)
+        self.heightSpeed = 0
+      else
+        self:changeHeight(newHeight)
+      end
+    end
+
+    for k, curGG in pairs(self.gaugeGuis) do
+      curGG:setGauge("gauge_hr", "height", self.height)
+    end
+  end,
+
+  updateFuelGauge = function(self)
+    if self.fuelGaugeVal ~= self.fuelGaugeTargetVal then
+      if self.fuelGaugeVal < self.fuelGaugeTargetVal then
+        self.fuelGaugeVal = math.min(self.fuelGaugeVal + self.fuelGaugeSpeed, self.fuelGaugeTargetVal)
+
+      else
+        self.fuelGaugeVal = math.max(self.fuelGaugeVal - self.fuelGaugeSpeed, self.fuelGaugeTargetVal)
+      end
+    end
+
+    for k, curGG in pairs(self.gaugeGuis) do
+      curGG:setGauge("gauge_fs", "fuel", self.fuelGaugeVal)
+      if self.curState.name ~= "landed" then
+        if self.fuelGaugeTargetVal <= self.tankCriticalWarningRatio then
+          curGG:setLedBlinking("gauge_fs", "fuel", true, 20, "heli-fuel-warning")
+
+        elseif self.fuelGaugeTargetVal <= self.tankWarningRatio then
+          curGG:setLedBlinking("gauge_fs", "fuel", true, 60, "heli-fuel-warning")
+
+        else
+          curGG:setLedBlinking("gauge_fs", "fuel", false)
+        end
+      else
+        curGG:setLedBlinking("gauge_fs", "fuel", false)
+      end
+    end
+  end,
+
+  updateEntityPositions = function(self)
+    local baseVec = math3d.vector2.rotate({0,1}, math.pi * 2 * self.baseEnt.orientation)
+    local vec = math3d.vector2.mul(baseVec, self.baseEnt.speed)
+
+    local basePos = self.baseEnt.position
+
+    self.childs.bodyEnt.teleport({x = basePos.x - vec[1], y = basePos.y - vec[2] + self.bodyOffset - self.curBobbing})
+    self.childs.rotorEnt.teleport({x = basePos.x - vec[1], y = basePos.y - vec[2] + self.rotorOffset - self.curBobbing})
+
+    self.childs.rotorEntShadow.teleport({x = basePos.x - vec[1], y = basePos.y - vec[2] +self.height})
+    self.childs.bodyEntShadow.teleport({x = basePos.x - vec[1], y = basePos.y - vec[2] + self.height})
+
+    if self.childs.floodlightEnt then
+      local lightOffsetVec = math3d.vector2.mul(baseVec, self.height)
+      self.childs.floodlightEnt.teleport({x = basePos.x - vec[1] - lightOffsetVec[1], y = basePos.y - vec[2] - lightOffsetVec[2] + self.height})
+    end
+
+    if self.childs.collisionEnt then
+      if not self.hasLandedCollider then
+        local initVec = {0,1}
+        local mul = 2
+        if self.baseEnt.speed < 0 then
+          initVec = {0,-1}
+          local x = self.baseEnt.orientation
+          mul = math.abs(math.sin(math.pi*2*x))*1.2 + math.sin(math.pi*x) + 3 --dont ask
+        end
+
+        vec = math3d.vector2.mul(math3d.vector2.rotate(initVec, math.pi * 2 * self.baseEnt.orientation), mul)
+        self.childs.collisionEnt.teleport({x = basePos.x - vec[1], y = basePos.y - vec[2]})
+        self.childs.collisionEnt.speed = self.baseEnt.speed
+
+      else
+        self.childs.collisionEnt.teleport({x = basePos.x - vec[1], y = basePos.y - vec[2]})
+        self.childs.collisionEnt.speed = self.baseEnt.speed
+      end
+    end
+
+
+    local off = (1 - math.sin(math.pi*self.baseEnt.orientation)) * 0.7
+    local center = {x = basePos.x, y = basePos.y - off}
+    local radius = 2
+    snap = self.baseEnt.orientation
+    snap = snap * (1 - math.sin(math.pi * snap)*0.05)
+    snap = math.abs(snap * 64) / 64
+    local vec = math3d.vector2.mul(math3d.vector2.rotate({0,1}, math.pi * 2 * snap), radius)
+
+    self.childs.burnerEnt.teleport({x = center.x + vec[1], y = center.y + vec[2] - self.curBobbing})
+
+    for k, curGG in pairs(self.gaugeGuis) do
+      curGG:setGauge("gauge_fs", "speed", math.abs(self.baseEnt.speed) * 216) --speed * 60 = m/s, * 3.6 = km/h
+    end
+  end,
+
+  updateEntityRotations = function(self)
+    self.childs.bodyEnt.orientation = self.baseEnt.orientation
+    self.childs.bodyEntShadow.orientation = self.baseEnt.orientation
+    self.childs.burnerEnt.orientation = self.baseEnt.orientation
+
+    if self.childs.collisionEnt then
+      self.childs.collisionEnt.orientation = self.baseEnt.orientation
+    end
+
+    if self.childs.floodlightEnt then
+      self.childs.floodlightEnt.orientation = self.baseEnt.orientation
+    end
+  end,
+
+  isBaseOrChild = function(self, ent)
+    if self.baseEnt == ent then
+      return true
+    end
+
+    for k,v in pairs(self.childs) do
+      if v == ent then
+        return true
+      end
+    end
+
+    if self.hasLandedCollider and self.childs.collisionEnt then
+      return self.childs.collisionEnt.isChildEntity(ent)
+    end
+
+    return false
+  end,
+
+  addGaugeGui = function(self, gg)
+    if #self.gaugeGuis == 0 then
+      self.gaugeGuis = {}
+    end
+
+    table.insert(self.gaugeGuis, gg)
+  end,
+
+  removeGaugeGui = function(self, gg)
+    for i, curGG in ipairs(self.gaugeGuis) do
+      if curGG == gg then
+        table.remove(self.gaugeGuis, i)
+        return
+      end
+    end
+  end,
 }

--- a/logic/heliBase.lua
+++ b/logic/heliBase.lua
@@ -509,6 +509,79 @@ heliBase = {
     end
   end,
 
+  -- called when the helicopter entity is damaged
+  -- evt - https://lua-api.factorio.com/latest/events.html#on_entity_damaged
+  OnDamaged = function(self, evt)
+
+    -- check if the helicopter is above the biters reach
+    if self.height <= maxCollisionHeight then
+      -- too low, within biters reach, allow damage
+      return
+    end
+
+    local damage_amount = evt.final_damage_amount
+    local damage_type = evt.damage_type.name
+    local cancelDamage = false
+
+    -- if evt.cause and evt.cause.valid then
+    -- don't check for validity, because the enemy that caused the damage might have been destroyed already
+    if evt.cause then
+        local cause = evt.cause
+      if evt.cause.type == "unit" then
+        -- damage caused by a unit (e.g. biters, spitters)
+        if evt.cause.prototype.attack_parameters and evt.cause.prototype.attack_parameters.ammo_type then
+          local attack_ammo_type = evt.cause.prototype.attack_parameters.ammo_type.category
+          if attack_ammo_type == "melee" then
+            -- attacked by a biter
+            if settings.global["heli-disable-biters-damage"].value then
+              cancelDamage = true
+            end
+          elseif attack_ammo_type == "biological" and damage_type == "acid" then
+            -- attacked by a spitter direct projectile
+            if settings.global["heli-disable-direct-spitter-damage"].value then
+              cancelDamage = true
+            end            
+          else
+            -- unknown attack ammo type
+            -- game.print("[".. attack_ammo_type .."] ("..damage_type..") Heli damaged by: " .. cause.name .. " (type: " .. cause.type .. ")" .. " damage: " .. damage_amount .. " health: " .. finalHealth)
+          end          
+        else
+          -- unit doesn't have attack_parameters, that is strange          
+        end
+      else
+        -- not a unit, could be an acid puddle
+        if string.find(cause.name, "acid-splash-fire", 1, true) then
+          -- stepped on an acid puddle
+          if settings.global["heli-disable-acid-splash-damage"].value then
+            cancelDamage = true
+          end
+        else
+          -- unknown entity, which is not a unit
+          -- game.print("NOT UNIT ("..damage_type..") - Heli damaged by: " .. cause.name .. " (type: " .. cause.type .. ")" .. " damage: " .. damage_amount .. " health: " .. finalHealth)
+        end
+      end
+    else
+      if damage_type == "acid" then
+        -- attacked by a spitter direct projectile (the spitter is already destroyed)
+        if settings.global["heli-disable-direct-spitter-damage"].value then
+          cancelDamage = true
+        end
+      else
+        -- unknown cause
+        -- game.print("("..damage_type..") Heli damaged by: unknown cause" .. " damage: " .. damage_amount .. " health: " .. finalHealth)
+      end
+    end
+
+    if cancelDamage then
+      -- restore health
+      if self.baseEnt and self.baseEnt.valid then
+        self.baseEnt.health = self.baseEnt.health + damage_amount
+      end
+    else
+      -- game.print("WARNING: damage not cancelled: " .. damage_type .. " " .. damage_amount)
+    end
+  end,
+
 
   ---------------- states ----------------
 

--- a/logic/heliController.lua
+++ b/logic/heliController.lua
@@ -1,370 +1,370 @@
 function getHeliControllerIndexByOwner(p)
-	if global.heliControllers then
-		for i, curController in ipairs(global.heliControllers) do
-			if curController.owner == p then
-				return i
-			end
-		end
-	end
+  if global.heliControllers then
+    for i, curController in ipairs(global.heliControllers) do
+      if curController.owner == p then
+        return i
+      end
+    end
+  end
 end
 
 function getHeliControllerByOwner(p)
-	local i = getHeliControllerIndexByowner(p)
-	if i then return global.heliControllers[i] end
+  local i = getHeliControllerIndexByowner(p)
+  if i then return global.heliControllers[i] end
 end
 
 function getHeliControllerIndexByHeli(heli)
-	if global.heliControllers then
-		for i, curController in ipairs(global.heliControllers) do
-			if curController.heli == heli then
-				return i
-			end
-		end
-	end
+  if global.heliControllers then
+    for i, curController in ipairs(global.heliControllers) do
+      if curController.heli == heli then
+        return i
+      end
+    end
+  end
 end
 
 function getHeliControllerByHeli(heli)
-	local i = getHeliControllerIndexByHeli(heli)
-	if i then return global.heliControllers[i] end
+  local i = getHeliControllerIndexByHeli(heli)
+  if i then return global.heliControllers[i] end
 end
 
 function assignHeliController(owner, heli, target, targetIsPlayer)
-	local oldControllerIndex = searchIndexInTable(global.heliControllers, heli, "heli")
-	
-	if oldControllerIndex then
-		global.heliControllers[oldControllerIndex]:destroy()
-		table.remove(global.heliControllers, oldControllerIndex)
-	end
+  local oldControllerIndex = searchIndexInTable(global.heliControllers, heli, "heli")
+  
+  if oldControllerIndex then
+    global.heliControllers[oldControllerIndex]:destroy()
+    table.remove(global.heliControllers, oldControllerIndex)
+  end
 
-	insertInGlobal("heliControllers", heliController.new(owner, heli, target, targetIsPlayer))
+  insertInGlobal("heliControllers", heliController.new(owner, heli, target, targetIsPlayer))
 end
 
 heliControllerState = {
-	getUp = 1,
-	orientToTarget = 2,
-	moveToTarget = 3,
-	creepToPosition = 4,
-	land = 5,
-	stop = 6,
+  getUp = 1,
+  orientToTarget = 2,
+  moveToTarget = 3,
+  creepToPosition = 4,
+  land = 5,
+  stop = 6,
 }
 
 heliController = 
 {
-	new = function(player, heli, target, targetIsPlayer)
-		local obj = 
-		{
-			valid = true,
+  new = function(player, heli, target, targetIsPlayer)
+    local obj = 
+    {
+      valid = true,
 
-			owner = player,
-			heli = heli,
-			targetIsPlayer = targetIsPlayer,
+      owner = player,
+      heli = heli,
+      targetIsPlayer = targetIsPlayer,
 
-			curStateId = heliControllerState.getUp,
-			stateChanged = true,
-		}
+      curStateId = heliControllerState.getUp,
+      stateChanged = true,
+    }
 
-		if targetIsPlayer then
-			obj.targetPlayer = target
-			obj.targetPos = target.position
-		else
-			obj.targetPos = target
-		end
+    if targetIsPlayer then
+      obj.targetPlayer = target
+      obj.targetPos = target.position
+    else
+      obj.targetPos = target
+    end
 
-		if not heli.baseEnt.get_driver() then
-			obj.driverIsBot = true
-			obj.driver = heli.surface.create_entity{name = "character", force = player.force, position = player.position}
-			heli.baseEnt.set_driver(obj.driver)
-		else
-			obj.driverIsBot = false
-			obj.driver = heli.baseEnt.get_driver()
-		end
+    if not heli.baseEnt.get_driver() then
+      obj.driverIsBot = true
+      obj.driver = heli.surface.create_entity{name = "character", force = player.force, position = player.position}
+      heli.baseEnt.set_driver(obj.driver)
+    else
+      obj.driverIsBot = false
+      obj.driver = heli.baseEnt.get_driver()
+    end
 
-		heli.hasRemoteController = true
-		heli.remoteController = obj
+    heli.hasRemoteController = true
+    heli.remoteController = obj
 
-		setmetatable(obj, {__index = heliController})
+    setmetatable(obj, {__index = heliController})
 
-		OnHeliControllerCreated(obj)
-		return obj
-	end,
+    OnHeliControllerCreated(obj)
+    return obj
+  end,
 
-	curState = function(self)
-		return heliControllerStates[self.curStateId](self)
-	end,
+  curState = function(self)
+    return heliControllerStates[self.curStateId](self)
+  end,
 
-	destroy = function(self)
-		self.valid = false
-		self.heli.hasRemoteController = nil
-		self.heli.remoteController = nil
+  destroy = function(self)
+    self.valid = false
+    self.heli.hasRemoteController = nil
+    self.heli.remoteController = nil
 
-		if self.driverIsBot and self.driver and self.driver.valid then
-			self.driver.destroy()
-		end
+    if self.driverIsBot and self.driver and self.driver.valid then
+      self.driver.destroy()
+    end
 
-		OnHeliControllerDestroyed(self)
-	end,
+    OnHeliControllerDestroyed(self)
+  end,
 
-	stopAndDestroy = function(self)
-		if self.driverIsBot then
+  stopAndDestroy = function(self)
+    if self.driverIsBot then
             -- Told to explicitly stop, make sure to clear the flag
             self.targetIsPlayer = false
-			self:changeState(heliControllerState.stop)
-		else
-			self:destroy()
-		end
-	end,
+      self:changeState(heliControllerState.stop)
+    else
+      self:destroy()
+    end
+  end,
 
-	OnTick = function(self)		
-		if not (self.heli.valid and self.heli.baseEnt.valid and self.owner.valid) then
-			self:destroy()
-			return
-		end
+  OnTick = function(self)    
+    if not (self.heli.valid and self.heli.baseEnt.valid and self.owner.valid) then
+      self:destroy()
+      return
+    end
 
-		local curDriver = self.heli.baseEnt.get_driver()
-		local curPassenger = self.heli.baseEnt.get_passenger()
+    local curDriver = self.heli.baseEnt.get_driver()
+    local curPassenger = self.heli.baseEnt.get_passenger()
 
-		if not (curDriver and curDriver.valid) then
-			if self.driverIsBot then
-				self:destroy()
-			else
-				self.driverIsBot = true
-				self.driver = self.heli.surface.create_entity{name = "character", force = self.owner.force, position = self.owner.position}
-				self.heli.baseEnt.set_driver(self.driver)
-				self.heli:OnUp()
-			end
+    if not (curDriver and curDriver.valid) then
+      if self.driverIsBot then
+        self:destroy()
+      else
+        self.driverIsBot = true
+        self.driver = self.heli.surface.create_entity{name = "character", force = self.owner.force, position = self.owner.position}
+        self.heli.baseEnt.set_driver(self.driver)
+        self.heli:OnUp()
+      end
 
-		elseif self.driverIsBot and curDriver ~= self.driver then
-			if self.driver and self.driver.valid then
-				self.driver.destroy()
-				self.driver = curDriver
-				self.driverIsBot = false
-			end
-			if self.targetIsPlayer and curDriver == self.targetPlayer.character then
-				self:destroy()
-				return
-			end
+    elseif self.driverIsBot and curDriver ~= self.driver then
+      if self.driver and self.driver.valid then
+        self.driver.destroy()
+        self.driver = curDriver
+        self.driverIsBot = false
+      end
+      if self.targetIsPlayer and curDriver == self.targetPlayer.character then
+        self:destroy()
+        return
+      end
 
-		elseif self.driverIsBot and curPassenger and curPassenger.valid then
-			if self.driver and self.driver.valid then
-				self.driver.destroy()
-				self.driver = curPassenger
-				self.driverIsBot = false
-			end
-			self.heli.baseEnt.set_driver(curPassenger)
-			
-			if self.targetIsPlayer and curPassenger == self.targetPlayer.character then
-				self:destroy()
-				return
-			end
+    elseif self.driverIsBot and curPassenger and curPassenger.valid then
+      if self.driver and self.driver.valid then
+        self.driver.destroy()
+        self.driver = curPassenger
+        self.driverIsBot = false
+      end
+      self.heli.baseEnt.set_driver(curPassenger)
+      
+      if self.targetIsPlayer and curPassenger == self.targetPlayer.character then
+        self:destroy()
+        return
+      end
 
-		else
-			if self.targetIsPlayer then
-				if self.targetPlayer.valid then
-					self.targetPos = {x = self.targetPlayer.position.x, y = self.targetPlayer.position.y - 1}
-				else
+    else
+      if self.targetIsPlayer then
+        if self.targetPlayer.valid then
+          self.targetPos = {x = self.targetPlayer.position.x, y = self.targetPlayer.position.y - 1}
+        else
                     -- Invalid player target, clear the flag
                     self.targetIsPlayer = false
-					self:stopAndDestroy()
-					return
-				end
-			end
+          self:stopAndDestroy()
+          return
+        end
+      end
 
-			local old = self.curStateId
-			self:curState()
+      local old = self.curStateId
+      self:curState()
 
-			if old == self.curStateId then
-				self.stateChanged = false
-			else
-				self.stateChanged = true
-			end
-		end
-	end,
+      if old == self.curStateId then
+        self.stateChanged = false
+      else
+        self.stateChanged = true
+      end
+    end
+  end,
 
-	changeState = function(self, newState)
-		self.curStateId = newState
-	end,
+  changeState = function(self, newState)
+    self.curStateId = newState
+  end,
 
-	setRidingState = function(self, acc, dir)
-		if not acc then
-			acc = self.driver.riding_state.acceleration
-		end
+  setRidingState = function(self, acc, dir)
+    if not acc then
+      acc = self.driver.riding_state.acceleration
+    end
 
-		if not dir then
-			dir = self.driver.riding_state.direction
-		end
+    if not dir then
+      dir = self.driver.riding_state.direction
+    end
 
-		self.driver.riding_state = {acceleration = acc, direction = dir}
-	end,
+    self.driver.riding_state = {acceleration = acc, direction = dir}
+  end,
 
-	holdSpeed = function(self, speed)
-		local dir = self.driver.riding_state.direction
+  holdSpeed = function(self, speed)
+    local dir = self.driver.riding_state.direction
 
-		if math.abs(1 - (self.heli.baseEnt.speed / speed)) < 0.05 then
-			self.heli.baseEnt.speed = speed
-		else
+    if math.abs(1 - (self.heli.baseEnt.speed / speed)) < 0.05 then
+      self.heli.baseEnt.speed = speed
+    else
 
-			if self.heli.baseEnt.speed > speed then
-				self:setRidingState(defines.riding.acceleration.braking)
-			else
-				self:setRidingState(defines.riding.acceleration.accelerating)
-			end
-		end
-	end,
+      if self.heli.baseEnt.speed > speed then
+        self:setRidingState(defines.riding.acceleration.braking)
+      else
+        self:setRidingState(defines.riding.acceleration.accelerating)
+      end
+    end
+  end,
 
-	getTargetOrientation = function(self)
-		local curPos = self.heli.childs.bodyEntShadow.position
+  getTargetOrientation = function(self)
+    local curPos = self.heli.childs.bodyEntShadow.position
 
-		local vec = {x = self.targetPos.x - curPos.x, y = curPos.y - self.targetPos.y}
-		local len = math.sqrt(vec.x ^ 2 + vec.y ^ 2)
+    local vec = {x = self.targetPos.x - curPos.x, y = curPos.y - self.targetPos.y}
+    local len = math.sqrt(vec.x ^ 2 + vec.y ^ 2)
 
-		vec.x = vec.x / len
-		vec.y = vec.y / len
+    vec.x = vec.x / len
+    vec.y = vec.y / len
 
 
-		local angle = math.atan2(vec.y, vec.x)
-		self.targetOrient = 1.25 - (angle / (2 * math.pi))
-		if self.targetOrient > 1 then self.targetOrient = self.targetOrient - 1 end
-	end,
+    local angle = math.atan2(vec.y, vec.x)
+    self.targetOrient = 1.25 - (angle / (2 * math.pi))
+    if self.targetOrient > 1 then self.targetOrient = self.targetOrient - 1 end
+  end,
 
-	getSteeringToTargetOrientation = function(self)
-		local curOrient = self.heli.baseEnt.orientation
+  getSteeringToTargetOrientation = function(self)
+    local curOrient = self.heli.baseEnt.orientation
 
-		if math.abs(self.targetOrient - curOrient) < 0.02 then
-			return defines.riding.direction.straight
-		else
-			local deltaLeft = 0
-			local deltaRight = 0
+    if math.abs(self.targetOrient - curOrient) < 0.02 then
+      return defines.riding.direction.straight
+    else
+      local deltaLeft = 0
+      local deltaRight = 0
 
-			if self.targetOrient < curOrient then
-				deltaLeft = curOrient - self.targetOrient
-				deltaRight = 1 - curOrient + self.targetOrient
-			else
-				deltaLeft = curOrient + 1 - self.targetOrient
-				deltaRight = self.targetOrient - curOrient
-			end
+      if self.targetOrient < curOrient then
+        deltaLeft = curOrient - self.targetOrient
+        deltaRight = 1 - curOrient + self.targetOrient
+      else
+        deltaLeft = curOrient + 1 - self.targetOrient
+        deltaRight = self.targetOrient - curOrient
+      end
 
-			if deltaLeft < deltaRight then
-				return defines.riding.direction.left
-			else
-				return defines.riding.direction.right
-			end
-		end
-	end,
+      if deltaLeft < deltaRight then
+        return defines.riding.direction.left
+      else
+        return defines.riding.direction.right
+      end
+    end
+  end,
 
-	------------- states ---------------
-	getUp = function(self)
-		if self.stateChanged then
-			self.heli:OnUp()
-		elseif self.heli.height >= maxCollisionHeight then
-			self:changeState(heliControllerState.orientToTarget)
-		end
-	end,
+  ------------- states ---------------
+  getUp = function(self)
+    if self.stateChanged then
+      self.heli:OnUp()
+    elseif self.heli.height >= maxCollisionHeight then
+      self:changeState(heliControllerState.orientToTarget)
+    end
+  end,
 
-	orientToTarget = function(self)
-		if self.stateChanged then
-			self.targetOrientation = self:getTargetOrientation()
-		else
-			local dir = self:getSteeringToTargetOrientation()
+  orientToTarget = function(self)
+    if self.stateChanged then
+      self.targetOrientation = self:getTargetOrientation()
+    else
+      local dir = self:getSteeringToTargetOrientation()
 
-			self:setRidingState(defines.riding.acceleration.nothing, dir)
+      self:setRidingState(defines.riding.acceleration.nothing, dir)
 
-			if dir == defines.riding.direction.straight then
-				self:changeState(heliControllerState.moveToTarget)
-			end
-		end
-	end,
+      if dir == defines.riding.direction.straight then
+        self:changeState(heliControllerState.moveToTarget)
+      end
+    end
+  end,
 
-	moveToTarget = function(self)
-		local dist = getDistance(self.heli.childs.bodyEntShadow.position, self.targetPos)
+  moveToTarget = function(self)
+    local dist = getDistance(self.heli.childs.bodyEntShadow.position, self.targetPos)
 
-		if self.stateChanged then
-			self.updateOrientationCooldown = 30
-			self.oldDist = -1
-		end
+    if self.stateChanged then
+      self.updateOrientationCooldown = 30
+      self.oldDist = -1
+    end
 
-		self.updateOrientationCooldown = self.updateOrientationCooldown - 1
-		if self.updateOrientationCooldown <  3 or dist < 10 then
-			if self.updateOrientationCooldown == 0 then
-				self.updateOrientationCooldown = 30
-				if dist >= 10 then
-					self:setRidingState(nil, defines.riding.direction.straight)
-				end
-			end
+    self.updateOrientationCooldown = self.updateOrientationCooldown - 1
+    if self.updateOrientationCooldown <  3 or dist < 10 then
+      if self.updateOrientationCooldown == 0 then
+        self.updateOrientationCooldown = 30
+        if dist >= 10 then
+          self:setRidingState(nil, defines.riding.direction.straight)
+        end
+      end
 
-			self.targetOrientation = self:getTargetOrientation()
-			self:setRidingState(nil, self:getSteeringToTargetOrientation())
-		else
-			--self:setRidingState(nil, defines.riding.direction.straight)
-		end
+      self.targetOrientation = self:getTargetOrientation()
+      self:setRidingState(nil, self:getSteeringToTargetOrientation())
+    else
+      --self:setRidingState(nil, defines.riding.direction.straight)
+    end
 
-		if dist < 150 then
-			local creepZone = 0.5
-			local landingZone = 1
-			local desiredSpeed = 1.5 - (1.2247448 - (dist - creepZone) / 150)^2
+    if dist < 150 then
+      local creepZone = 0.5
+      local landingZone = 1
+      local desiredSpeed = 1.5 - (1.2247448 - (dist - creepZone) / 150)^2
 
-			self:holdSpeed(desiredSpeed)
+      self:holdSpeed(desiredSpeed)
 
-			if dist <= landingZone and (dist <= creepZone or dist == self.oldDist) then
-				self:setRidingState(defines.riding.acceleration.braking)
-				self:changeState(heliControllerState.creepToPosition)
-			end
+      if dist <= landingZone and (dist <= creepZone or dist == self.oldDist) then
+        self:setRidingState(defines.riding.acceleration.braking)
+        self:changeState(heliControllerState.creepToPosition)
+      end
 
-			self.oldDist = dist
-		else
-			self:setRidingState(defines.riding.acceleration.accelerating)
-		end
-	end,
+      self.oldDist = dist
+    else
+      self:setRidingState(defines.riding.acceleration.accelerating)
+    end
+  end,
 
-	creepToPosition = function(self)
-		local curPos = self.heli.childs.bodyEntShadow.position
-		
-		if self.stateChanged then
-			self:setRidingState(defines.riding.acceleration.braking, defines.riding.direction.straight)
-			self.heli.baseEnt.speed = 0
+  creepToPosition = function(self)
+    local curPos = self.heli.childs.bodyEntShadow.position
+    
+    if self.stateChanged then
+      self:setRidingState(defines.riding.acceleration.braking, defines.riding.direction.straight)
+      self.heli.baseEnt.speed = 0
             --targetIsPlayer will be updated else where
-			--self.targetIsPlayer = false
+      --self.targetIsPlayer = false
 
-			local curDist = getDistance(curPos, self.targetPos)
-			local alignFactor = 1.1
-			local alignVec = {x = (self.targetPos.x - curPos.x) / curDist * alignFactor,  y = (self.targetPos.y - curPos.y) / curDist * alignFactor}
-			self.targetPos = {x = self.targetPos.x + alignVec.x, y = self.targetPos.y + alignVec.y}
+      local curDist = getDistance(curPos, self.targetPos)
+      local alignFactor = 1.1
+      local alignVec = {x = (self.targetPos.x - curPos.x) / curDist * alignFactor,  y = (self.targetPos.y - curPos.y) / curDist * alignFactor}
+      self.targetPos = {x = self.targetPos.x + alignVec.x, y = self.targetPos.y + alignVec.y}
 
-			local creepFrames = 60
-			self.creepVec = {x = (self.targetPos.x - curPos.x) / creepFrames, y = (self.targetPos.y - curPos.y) / creepFrames}
+      local creepFrames = 60
+      self.creepVec = {x = (self.targetPos.x - curPos.x) / creepFrames, y = (self.targetPos.y - curPos.y) / creepFrames}
 
-			self.oldDist = 100
-		end
+      self.oldDist = 100
+    end
 
-		self.heli.baseEnt.teleport({x = self.heli.baseEnt.position.x + self.creepVec.x, y = self.heli.baseEnt.position.y + self.creepVec.y})
-		self.heli:updateEntityPositions()
+    self.heli.baseEnt.teleport({x = self.heli.baseEnt.position.x + self.creepVec.x, y = self.heli.baseEnt.position.y + self.creepVec.y})
+    self.heli:updateEntityPositions()
 
-		local dist = getDistance(self.heli.childs.bodyEntShadow.position, self.targetPos)
-		if dist < 0.2 or dist > self.oldDist then
+    local dist = getDistance(self.heli.childs.bodyEntShadow.position, self.targetPos)
+    if dist < 0.2 or dist > self.oldDist then
             -- If targeting the player and we shouldn't land when we catch up, then just stop, otherwise land
             if( self.targetIsPlayer and self.targetPlayer.mod_settings["heli-remote-dont-land-following-player"].value )then
                 self:changeState(heliControllerState.stop)
             else
                 self:changeState(heliControllerState.land)
             end
-		end
+    end
 
-		self.oldDist = dist
-	end,
+    self.oldDist = dist
+  end,
 
-	land = function(self)
-		local d = extractPlayer(self.driver)
+  land = function(self)
+    local d = extractPlayer(self.driver)
         
         if not ((not self.driverIsBot and d and d.valid) and d.mod_settings["heli-remote-dont-auto-land-player"].value) then
             self.heli:OnDown()
         end
 
-		self:destroy()
-	end,
+    self:destroy()
+  end,
 
-	stop = function(self)
-		self:setRidingState(defines.riding.acceleration.braking, defines.riding.direction.straight)
-		
-		if self.heli.baseEnt.speed == 0 then
+  stop = function(self)
+    self:setRidingState(defines.riding.acceleration.braking, defines.riding.direction.straight)
+    
+    if self.heli.baseEnt.speed == 0 then
             if( self.targetIsPlayer and self.targetPlayer.mod_settings["heli-remote-dont-land-following-player"].value )then
                 local dist = getDistance(self.heli.childs.bodyEntShadow.position, self.targetPos)
                 if dist > 0.2 then
@@ -374,16 +374,16 @@ heliController =
             else
                 self:changeState(heliControllerState.land)
             end
-		end
-	end,
-	------------------------------------
+    end
+  end,
+  ------------------------------------
 }
 
 heliControllerStates = {
-	heliController.getUp,
-	heliController.orientToTarget,
-	heliController.moveToTarget,
-	heliController.creepToPosition,
-	heliController.land,
-	heliController.stop,
+  heliController.getUp,
+  heliController.orientToTarget,
+  heliController.moveToTarget,
+  heliController.creepToPosition,
+  heliController.land,
+  heliController.stop,
 }

--- a/logic/heliPad.lua
+++ b/logic/heliPad.lua
@@ -1,116 +1,116 @@
 function getHeliPadIndexFromBaseEntity(ent)
-	for i, v in ipairs(global.heliPads) do
-		if v.baseEnt == ent then
-			return i
-		end
-	end
+  for i, v in ipairs(global.heliPads) do
+    if v.baseEnt == ent then
+      return i
+    end
+  end
 
-	return nil
+  return nil
 end
 
 heliPad = 
 {
-	new = function(placementEnt)
-		local obj = 
-		{
-			valid = true,
+  new = function(placementEnt)
+    local obj = 
+    {
+      valid = true,
 
-			surface = placementEnt.surface,
+      surface = placementEnt.surface,
 
-			replacedTiles = {},
-			baseEnt = placementEnt.surface.create_entity
-			{
-				name = "heli-pad-entity",
-				force = placementEnt.force,
-				position = placementEnt.position,
-			}
-		}
+      replacedTiles = {},
+      baseEnt = placementEnt.surface.create_entity
+      {
+        name = "heli-pad-entity",
+        force = placementEnt.force,
+        position = placementEnt.position,
+      }
+    }
 
-		--game.players[1].print("calc: ".. tostring(placementEnt.position.y - heli_pad_sprite_y_shift).. " real pos: "..tostring(obj.baseEnt.position.y))
-		--game.players[1].print(tostring(placementEnt.position.x) .. "|" .. tostring(placementEnt.position.y))
+    --game.players[1].print("calc: ".. tostring(placementEnt.position.y - heli_pad_sprite_y_shift).. " real pos: "..tostring(obj.baseEnt.position.y))
+    --game.players[1].print(tostring(placementEnt.position.x) .. "|" .. tostring(placementEnt.position.y))
 
-		local boundingBox = 
-		{
-			left_top = {placementEnt.position.x - 3.5, placementEnt.position.y - 3.5},
-			right_bottom = {placementEnt.position.x + 3.5, placementEnt.position.y + 3.5}
-		}
+    local boundingBox = 
+    {
+      left_top = {placementEnt.position.x - 3.5, placementEnt.position.y - 3.5},
+      right_bottom = {placementEnt.position.x + 3.5, placementEnt.position.y + 3.5}
+    }
 
-		local scorches = obj.surface.find_entities_filtered
-		{
-			area = boundingBox,
-			type = "corpse",
-			name = "small-scorchmark",
-		}
+    local scorches = obj.surface.find_entities_filtered
+    {
+      area = boundingBox,
+      type = "corpse",
+      name = "small-scorchmark",
+    }
 
-		for k,v in pairs(scorches) do
-			v.destroy()
-		end
+    for k,v in pairs(scorches) do
+      v.destroy()
+    end
 
-		local tiles = {}
-		for i = -3, 3 do
-			obj.replacedTiles[i] = {}
+    local tiles = {}
+    for i = -3, 3 do
+      obj.replacedTiles[i] = {}
 
-			for j = -3, 3 do
-				table.insert(tiles, 
-				{
-					name = "heli-pad-concrete", 
-					position = {x = placementEnt.position.x + i, y = placementEnt.position.y + j} 
-				})
+      for j = -3, 3 do
+        table.insert(tiles, 
+        {
+          name = "heli-pad-concrete", 
+          position = {x = placementEnt.position.x + i, y = placementEnt.position.y + j} 
+        })
 
-				local oldTile = obj.surface.get_tile(placementEnt.position.x + i, placementEnt.position.y + j)
+        local oldTile = obj.surface.get_tile(placementEnt.position.x + i, placementEnt.position.y + j)
 
-				obj.replacedTiles[i][j] = {
-					name = oldTile.name,
-					position = oldTile.position
-				}
-			end
-		end
+        obj.replacedTiles[i][j] = {
+          name = oldTile.name,
+          position = oldTile.position
+        }
+      end
+    end
 
-		obj.surface.set_tiles(tiles, true)
+    obj.surface.set_tiles(tiles, true)
 
-		placementEnt.destroy()
-		return setmetatable(obj, {__index = heliPad})
-	end,
+    placementEnt.destroy()
+    return setmetatable(obj, {__index = heliPad})
+  end,
 
-	destroy = function(self)
-		self.valid = false
+  destroy = function(self)
+    self.valid = false
 
-		local restoredTiles = {}
+    local restoredTiles = {}
 
-		for i = -3, 3 do
-			for j = -3, 3 do
-				if self.surface.get_tile(self.baseEnt.position.x + i, self.baseEnt.position.y + j).name == "heli-pad-concrete" then
-					self:migrateTile(self.replacedTiles[i][j])
+    for i = -3, 3 do
+      for j = -3, 3 do
+        if self.surface.get_tile(self.baseEnt.position.x + i, self.baseEnt.position.y + j).name == "heli-pad-concrete" then
+          self:migrateTile(self.replacedTiles[i][j])
 
-					table.insert(restoredTiles, self.replacedTiles[i][j])
-				end
-			end
-		end
+          table.insert(restoredTiles, self.replacedTiles[i][j])
+        end
+      end
+    end
 
-		self.surface.set_tiles(restoredTiles, true)
-	end,
+    self.surface.set_tiles(restoredTiles, true)
+  end,
 
-	tile_migrations =
-	{
-		{
-			{"grass", "grass-1"},
-			{"grass-medium", "grass-3"},
-			{"grass-dry", "grass-2"},
-			{"dirt", "dirt-3"},
-			{"dirt-dark", "dirt-6"},
-			{"sand", "sand-1"},
-			{"sand-dark", "sand-3"}
-		},
-	},
+  tile_migrations =
+  {
+    {
+      {"grass", "grass-1"},
+      {"grass-medium", "grass-3"},
+      {"grass-dry", "grass-2"},
+      {"dirt", "dirt-3"},
+      {"dirt-dark", "dirt-6"},
+      {"sand", "sand-1"},
+      {"sand-dark", "sand-3"}
+    },
+  },
 
-	migrateTile = function(self, tile)
-		for i, curMigrationTable in ipairs(self.tile_migrations) do
-			for k, curMigration in pairs(curMigrationTable) do
-				if curMigration[1] == tile.name then
-					tile.name = curMigration[2]
-					break
-				end
-			end
-		end
-	end,
+  migrateTile = function(self, tile)
+    for i, curMigrationTable in ipairs(self.tile_migrations) do
+      for k, curMigration in pairs(curMigrationTable) do
+        if curMigration[1] == tile.name then
+          tile.name = curMigration[2]
+          break
+        end
+      end
+    end
+  end,
 }

--- a/logic/mtMgr.lua
+++ b/logic/mtMgr.lua
@@ -9,58 +9,58 @@
 
 mtMgr =
 {
-	--It's worth noting that this table gets rebuilt everytime the mod is loaded,
-	--which allows updating metatables.
-	assignments = {},
+  --It's worth noting that this table gets rebuilt everytime the mod is loaded,
+  --which allows updating metatables.
+  assignments = {},
 
 
-	--Use this at the file level to assign a metatable to a type identifier.
-	--The given metatable will be used on objects of this type in OnLoad and set.
-	assign = function(strType, metatable)
-		mtMgr.assignments[strType] = metatable
-	end,
+  --Use this at the file level to assign a metatable to a type identifier.
+  --The given metatable will be used on objects of this type in OnLoad and set.
+  assign = function(strType, metatable)
+    mtMgr.assignments[strType] = metatable
+  end,
 
 
-	--This will set the metatable assigned in assign() and save the type identifier to the object.
-	set = function(obj, strType)
-		obj.__mtMgr_type = strType
-		return setmetatable(obj, mtMgr.assignments[strType])
-	end,
+  --This will set the metatable assigned in assign() and save the type identifier to the object.
+  set = function(obj, strType)
+    obj.__mtMgr_type = strType
+    return setmetatable(obj, mtMgr.assignments[strType])
+  end,
 
 
-	crawl = function(t, f, lookup)
-		if not lookup then
-			lookup = {}
-		end
+  crawl = function(t, f, lookup)
+    if not lookup then
+      lookup = {}
+    end
 
-		lookup[t] = true
+    lookup[t] = true
 
-		--Reading nil fields on game tables will trigger an error.
-		--This works for now.
-		if not t.__self then
-			f(t)
+    --Reading nil fields on game tables will trigger an error.
+    --This works for now.
+    if not t.__self then
+      f(t)
 
-			for k,v in pairs(t) do
-				if type(v) == "table" and not lookup[v] then
-					mtMgr.crawl(v, f, lookup)
-				end
-			end
-		end
-	end,
+      for k,v in pairs(t) do
+        if type(v) == "table" and not lookup[v] then
+          mtMgr.crawl(v, f, lookup)
+        end
+      end
+    end
+  end,
 
 
-	--Call this in script.on_load.
-	--Walks the entire global table or the one you passed. If it encounters a table with a type identifier,
-	--it sets the metatable assigned to the type on that table.
-	--Circular references are safe.
-	OnLoad = function(t)
-		t = t or global
+  --Call this in script.on_load.
+  --Walks the entire global table or the one you passed. If it encounters a table with a type identifier,
+  --it sets the metatable assigned to the type on that table.
+  --Circular references are safe.
+  OnLoad = function(t)
+    t = t or global
 
-		mtMgr.crawl(global, function(t)
-			local mt = mtMgr.assignments[t.__mtMgr_type]
-			if mt then
-				setmetatable(t, mt)
-			end
-		end)
-	end,
+    mtMgr.crawl(global, function(t)
+      local mt = mtMgr.assignments[t.__mtMgr_type]
+      if mt then
+        setmetatable(t, mt)
+      end
+    end)
+  end,
 }

--- a/logic/simpleNoise.lua
+++ b/logic/simpleNoise.lua
@@ -4,49 +4,49 @@
 
 simpleNoise =
 {
-	new = function(magnitude, timeAdvance, minFrequency, maxFrequency)
-		local obj =
-		{
-			magnitude = magnitude or 1,
-			timeAdvance = timeAdvance or 0.2,
-			minFrequency = minFrequency or 1,
-			maxFrequency = maxFrequency or 6,
+  new = function(magnitude, timeAdvance, minFrequency, maxFrequency)
+    local obj =
+    {
+      magnitude = magnitude or 1,
+      timeAdvance = timeAdvance or 0.2,
+      minFrequency = minFrequency or 1,
+      maxFrequency = maxFrequency or 6,
 
-			nextVal = 0,
-			lastVal = 0,
+      nextVal = 0,
+      lastVal = 0,
 
-			transitionTime = 0,
-			curTime = 0,
-		}
+      transitionTime = 0,
+      curTime = 0,
+    }
 
-		obj.maxFrequency = obj.maxFrequency - obj.minFrequency
+    obj.maxFrequency = obj.maxFrequency - obj.minFrequency
 
-		return mtMgr.set(obj, "simpleNoise")
-	end,
+    return mtMgr.set(obj, "simpleNoise")
+  end,
 
-	easing = function(t)
-		if t < 0.5 then
-			return 2*t^2
-		else
-			return -1+(4-2*t)*t
-		end
-	end,
+  easing = function(t)
+    if t < 0.5 then
+      return 2*t^2
+    else
+      return -1+(4-2*t)*t
+    end
+  end,
 
-	advance = function(self)
-		self.curTime = self.curTime + self.timeAdvance
+  advance = function(self)
+    self.curTime = self.curTime + self.timeAdvance
 
-		if self.curTime >= self.transitionTime then
-			self.lastVal = self.nextVal
-			self.nextVal = math.random() * 2 - 1
+    if self.curTime >= self.transitionTime then
+      self.lastVal = self.nextVal
+      self.nextVal = math.random() * 2 - 1
 
-			self.valDelta = self.nextVal - self.lastVal
+      self.valDelta = self.nextVal - self.lastVal
 
-			self.curTime = 0
-			self.transitionTime = math.random() * self.maxFrequency + self.minFrequency
-		end
+      self.curTime = 0
+      self.transitionTime = math.random() * self.maxFrequency + self.minFrequency
+    end
 
-		return (self.lastVal + self.valDelta * self.easing(self.curTime / self.transitionTime)) * self.magnitude
-	end,
+    return (self.lastVal + self.valDelta * self.easing(self.curTime / self.transitionTime)) * self.magnitude
+  end,
 }
 
 mtMgr.assign("simpleNoise", {__index = simpleNoise})

--- a/logic/timer.lua
+++ b/logic/timer.lua
@@ -1,78 +1,78 @@
 timer =
 {
-	new = function(func, frames, isInterval, timerData)
-		local timer = 
-		{
-			valid = true,
-			callback = func,
-			runTick = game.tick + frames,
-			interval = isInterval and frames,
-			paused = false,
-			data = timerData,
-		}
+  new = function(func, frames, isInterval, timerData)
+    local timer = 
+    {
+      valid = true,
+      callback = func,
+      runTick = game.tick + frames,
+      interval = isInterval and frames,
+      paused = false,
+      data = timerData,
+    }
 
-		mtMgr.set(timer, "timer")
+    mtMgr.set(timer, "timer")
 
-		return insertInGlobal("timers", timer)
-	end,
+    return insertInGlobal("timers", timer)
+  end,
 
-	cancel = function(self)
-		self.valid = false
-	end,
+  cancel = function(self)
+    self.valid = false
+  end,
 
-	pause = function(self)
-		self.paused = true
-		self.remaining = self.runTick - game.tick
-	end,
+  pause = function(self)
+    self.paused = true
+    self.remaining = self.runTick - game.tick
+  end,
 
-	resume = function(self)
-		self.paused = false
-		self.runTick = game.tick + self.remaining
-	end,
+  resume = function(self)
+    self.paused = false
+    self.runTick = game.tick + self.remaining
+  end,
 }
 
 function setTimeout(func, frames, timerData)
-	return timer.new(func, frames, false, timerData)
+  return timer.new(func, frames, false, timerData)
 end
 
 function setInterval(func, frames, timerData)
-	return timer.new(func, frames, true, timerData)
+  return timer.new(func, frames, true, timerData)
 end
 
 function OnTimerTick()
-	local timers = global.timers
+  local timers = global.timers
 
-	if timers then
-		for i = #timers, 1, -1 do
-			local curTimer = timers[i]
+  if timers then
+    for i = #timers, 1, -1 do
+      local curTimer = timers[i]
 
-			if not curTimer.valid then
-				table.remove(timers, i)
-			
-			else
-				if (not curTimer.paused) and curTimer.runTick <= game.tick then
-					-- i don't know if this check is the correct way to catch it
-					-- but sometimes after game load, the callback slot will be
-					-- empty and cause a crash. this appears to fix that.
-					-- seems this is only used by the fuel gauge as well
-					if not curTimer.callback then
-						curTimer.valid = false
-						table.remove(timers, i)
-					else
-						curTimer:callback()
+      if not curTimer.valid then
+        table.remove(timers, i)
+      
+      else
+        if (not curTimer.paused) and curTimer.runTick <= game.tick then
+          -- i don't know if this check is the correct way to catch it
+          -- but sometimes after game load, the callback slot will be
+          -- empty and cause a crash. this appears to fix that.
+          -- seems this is only used by the fuel gauge as well
+          if not curTimer.callback then
+            curTimer.valid = false
+            table.remove(timers, i)
+          else
+            curTimer:callback()
 
-						if curTimer.interval then
-							curTimer.runTick = game.tick + curTimer.interval
+            if curTimer.interval then
+              curTimer.runTick = game.tick + curTimer.interval
 
-						else
-							curTimer.valid = false
-							table.remove(timers, i)
-						end
-					end
-				end
-			end
-		end 
-	end
+            else
+              curTimer.valid = false
+              table.remove(timers, i)
+            end
+          end
+        end
+      end
+    end 
+  end
 end
 
 mtMgr.assign("timer", {__index = timer})

--- a/logic/util.lua
+++ b/logic/util.lua
@@ -1,166 +1,166 @@
 function tableToString(table)
-	local s = ""
-	for k,v in pairs(table) do
-		s = s .. type(v) .. " '" .. k .. "': " .. tostring(v) .. "\n"
-	end
-	return s
+  local s = ""
+  for k,v in pairs(table) do
+    s = s .. type(v) .. " '" .. k .. "': " .. tostring(v) .. "\n"
+  end
+  return s
 end
 
 function printTable(t, prefix)
-	if not prefix then
-		prefix = ""
-	end
+  if not prefix then
+    prefix = ""
+  end
 
-	for k,v in pairs(t) do
-		local typ = "[" .. type(v) .. "] "
-		local name = "'" .. k .. "' ="
-		local val = " " .. tostring(v)
+  for k,v in pairs(t) do
+    local typ = "[" .. type(v) .. "] "
+    local name = "'" .. k .. "' ="
+    local val = " " .. tostring(v)
 
-		if type(v) == "table" then
-			printA(prefix .. typ .. name)
-			printTable(v, prefix .. "___")
+    if type(v) == "table" then
+      printA(prefix .. typ .. name)
+      printTable(v, prefix .. "___")
 
-		else
-			printA(prefix .. typ .. name .. val)
-		end
-	end
+    else
+      printA(prefix .. typ .. name .. val)
+    end
+  end
 end
 
 function printA(...)
-	local s = ""
-	local n = select("#", ...)
-	for i = 1, n do
-		s = s .. tostring(select(i, ...))
-		if i < n then 
-			s = s .. ", "
-		end
-	end
+  local s = ""
+  local n = select("#", ...)
+  for i = 1, n do
+    s = s .. tostring(select(i, ...))
+    if i < n then 
+      s = s .. ", "
+    end
+  end
 
-	for k,v in pairs(game.players) do
-		v.print(s)
-	end
+  for k,v in pairs(game.players) do
+    v.print(s)
+  end
 
-	return s
+  return s
 end
 
 function printAF(...)
-	local t = {...}
-	table.insert(t, math.random())
-	return printA(unpack(t))
+  local t = {...}
+  table.insert(t, math.random())
+  return printA(unpack(t))
 end
 
 function getDistance(pos1, pos2)
-	return math.sqrt((pos2.x - pos1.x)^2 + (pos2.y - pos1.y)^2)
+  return math.sqrt((pos2.x - pos1.x)^2 + (pos2.y - pos1.y)^2)
 end
 
 function equipmentGridHasItem(grid, itemName)
-	local contents = grid.get_contents()
-	return contents[itemName] and contents[itemName] > 0
+  local contents = grid.get_contents()
+  return contents[itemName] and contents[itemName] > 0
 end
 
 function searchIndexInTable(table, obj, field)
-	if table then
-		for i, v in ipairs(table) do
-			if field and v[field] == obj then
-				return i
-			elseif v == obj then
-				return i
-			end
-		end
-	end
+  if table then
+    for i, v in ipairs(table) do
+      if field and v[field] == obj then
+        return i
+      elseif v == obj then
+        return i
+      end
+    end
+  end
 end
 
 function searchInTable(table, obj, field)
-	if table then
-		for k, v in pairs(table) do
-			if field and v[field] == obj then
-				return v
-			elseif v == obj then
-				return v
-			end
-		end
-	end
+  if table then
+    for k, v in pairs(table) do
+      if field and v[field] == obj then
+        return v
+      elseif v == obj then
+        return v
+      end
+    end
+  end
 end
 
 function setMetatablesInGlobal(name, mt)
-	if global[name] then
-		for k, v in pairs(global[name]) do
-			setmetatable(v, mt)
-		end
-	end
+  if global[name] then
+    for k, v in pairs(global[name]) do
+      setmetatable(v, mt)
+    end
+  end
 end
 
 function checkAndTickInGlobal(name)
-	if global[name] then
-		for i = #global[name], 1, -1 do
-			local v = global[name][i]
+  if global[name] then
+    for i = #global[name], 1, -1 do
+      local v = global[name][i]
 
-			if v.valid then
-				v:OnTick()
-			else
-				table.remove(global[name], i)
-			end
-		end
-	end
+      if v.valid then
+        v:OnTick()
+      else
+        table.remove(global[name], i)
+      end
+    end
+  end
 end
 
 function callInGlobal(gName, kName, ...)
-	if global[gName] then
-		for k,v in pairs(global[gName]) do
-			if v[kName] then v[kName](v, ...) end
-		end
-	end
+  if global[gName] then
+    for k,v in pairs(global[gName]) do
+      if v[kName] then v[kName](v, ...) end
+    end
+  end
 end
 
 function insertInGlobal(gName, val)
-	if not global[gName] then global[gName] = {} end
-	table.insert(global[gName], val)
-	return val
+  if not global[gName] then global[gName] = {} end
+  table.insert(global[gName], val)
+  return val
 end
 
 function removeInGlobal(gName, val)
-	if global[gName] then
-		for i, v in ipairs(global[gName]) do
-			if v == val then
-				table.remove(global[gName], i)
-				return v
-			end
-		end
-	end
+  if global[gName] then
+    for i, v in ipairs(global[gName]) do
+      if v == val then
+        table.remove(global[gName], i)
+        return v
+      end
+    end
+  end
 end
 
 function fEqual(a, b, prec)
-	if not prec then
-		prec = 0.001
-	end
+  if not prec then
+    prec = 0.001
+  end
 
-	return math.abs(a - b) <= prec
+  return math.abs(a - b) <= prec
 end
 
 function versionStrToInt(s)
-	v = 0
-	for num in s:gmatch("%d+") do
-		v = v * 100 + tonumber(num)
-	end
+  v = 0
+  for num in s:gmatch("%d+") do
+    v = v * 100 + tonumber(num)
+  end
 
-	return v
+  return v
 end
 
 function concatStrTable(t, c)
-	local s = ""
-	for k,v in pairs(t) do
-		s = s .. v .. c
-	end
+  local s = ""
+  for k,v in pairs(t) do
+    s = s .. v .. c
+  end
 
-	return s
+  return s
 end
 
 function getIndexedPos(pos)
-	if pos[1] and pos[2] then
-		return {pos[1], pos[2]}
-	elseif pos.x and pos.y then
-		return {pos.x, pos.y}
-	end	
+  if pos[1] and pos[2] then
+    return {pos[1], pos[2]}
+  elseif pos.x and pos.y then
+    return {pos.x, pos.y}
+  end  
 end
 
 string.startswith = function(str, strSub)
@@ -172,42 +172,42 @@ string.startswith = function(str, strSub)
 end
 
 function chopDecimal(val, place)
-	local mult = 10^(place or 0)
-	return math.floor(val * mult + 0.5) / mult
+  local mult = 10^(place or 0)
+  return math.floor(val * mult + 0.5) / mult
 end
 
 function extractPlayer (obj)
-	if obj and obj.valid then
-		if obj.is_player() then
-			return obj
+  if obj and obj.valid then
+    if obj.is_player() then
+      return obj
 
-		elseif obj.player and obj.player.valid and obj.player.is_player() then
-			return obj.player
-		end
-	end
+    elseif obj.player and obj.player.valid and obj.player.is_player() then
+      return obj.player
+    end
+  end
 
-	return nil
+  return nil
 end
 
 function getCarPlayers(car)
-	local d = extractPlayer(car.get_driver())
-	local p = extractPlayer(car.get_passenger())
+  local d = extractPlayer(car.get_driver())
+  local p = extractPlayer(car.get_passenger())
 
-	local t = {}
+  local t = {}
 
-	if d then
-		table.insert(t, d)
-	end
+  if d then
+    table.insert(t, d)
+  end
 
-	if p then
-		table.insert(t, p)
-	end
+  if p then
+    table.insert(t, p)
+  end
 
-	return t
+  return t
 end
 
 function playerHasEquipment(p, equipName)
-	return p.character and p.character.valid and
-		p.character.grid and p.character.grid.valid and
-		equipmentGridHasItem(p.character.grid, equipName)
+  return p.character and p.character.valid and
+    p.character.grid and p.character.grid.valid and
+    equipmentGridHasItem(p.character.grid, equipName)
 end

--- a/migrations/Helicopters_0.0.3.json
+++ b/migrations/Helicopters_0.0.3.json
@@ -1,14 +1,14 @@
 {
-	"entity":
-	[
-		["heli-entity", "heli-entity-_-"],
-		["heli-placement-entity", "heli-placement-entity-_-"],
-		["heli-body-entity", "heli-body-entity-_-"],
-		["heli-flying-collision-entity", "heli-flying-collision-entity-_-"],
-		["heli-landed-collision-entity", "heli-landed-collision-entity-_-"],
-		["heli-shadow-entity", "heli-shadow-entity-_-"],
-		["heli-burner-entity", "heli-burner-entity-_-"],
-		["rotor-entity", "rotor-entity-_-"],
-		["rotor-shadow-entity", "rotor-shadow-entity-_-"]
-	]
+  "entity":
+  [
+    ["heli-entity", "heli-entity-_-"],
+    ["heli-placement-entity", "heli-placement-entity-_-"],
+    ["heli-body-entity", "heli-body-entity-_-"],
+    ["heli-flying-collision-entity", "heli-flying-collision-entity-_-"],
+    ["heli-landed-collision-entity", "heli-landed-collision-entity-_-"],
+    ["heli-shadow-entity", "heli-shadow-entity-_-"],
+    ["heli-burner-entity", "heli-burner-entity-_-"],
+    ["rotor-entity", "rotor-entity-_-"],
+    ["rotor-shadow-entity", "rotor-shadow-entity-_-"]
+  ]
 }

--- a/prototypes/equipment/equipment.lua
+++ b/prototypes/equipment/equipment.lua
@@ -1,37 +1,37 @@
 data:extend({
-	{
-		type = "battery-equipment",
-		name = "heli-remote-equipment",
-		sprite =
-		{
-			filename = "__HelicopterRevival__/graphics/equipment/heli-remote-equipment.png",
-			width = 128,
-			height = 128,
-			priority = "medium",
-			scale = 0.5,
-		},
-		shape =
-		{
-			width = 2,
-			height = 2,
-			type = "full"
-		},
-		energy_source =
-		{
-			type = "electric",
-			buffer_capacity = "2MJ",
-			input_flow_limit = "1MW",
-			output_flow_limit = "1MW",
-			usage_priority = "tertiary"
-		},
-		categories = {"armor"}
-	},
-	-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-	{ -- Gunship grid
-		type = "equipment-grid",
-		name = "heli-equipment-grid",
-		width = 8,
-		height = 4,
-		equipment_categories = {"armor"}
-	},
+  {
+    type = "battery-equipment",
+    name = "heli-remote-equipment",
+    sprite =
+    {
+      filename = "__HelicopterRevival__/graphics/equipment/heli-remote-equipment.png",
+      width = 128,
+      height = 128,
+      priority = "medium",
+      scale = 0.5,
+    },
+    shape =
+    {
+      width = 2,
+      height = 2,
+      type = "full"
+    },
+    energy_source =
+    {
+      type = "electric",
+      buffer_capacity = "2MJ",
+      input_flow_limit = "1MW",
+      output_flow_limit = "1MW",
+      usage_priority = "tertiary"
+    },
+    categories = {"armor"}
+  },
+  -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  { -- Gunship grid
+    type = "equipment-grid",
+    name = "heli-equipment-grid",
+    width = 8,
+    height = 4,
+    equipment_categories = {"armor"}
+  },
 })

--- a/prototypes/items/heli_item.lua
+++ b/prototypes/items/heli_item.lua
@@ -1,13 +1,13 @@
 data:extend({
-	{
-		type = "item-with-entity-data",
-		name = "heli-item",
-		icon = "__HelicopterRevival__/graphics/icons/heli.png",
-		icon_size = 64,
-		flags = {},
-		subgroup = "transport",
-		order = "b[personal-transport]-c[heli]",
-		place_result = "heli-placement-entity-_-",
-		stack_size = 1
-	}
+  {
+    type = "item-with-entity-data",
+    name = "heli-item",
+    icon = "__HelicopterRevival__/graphics/icons/heli.png",
+    icon_size = 64,
+    flags = {},
+    subgroup = "transport",
+    order = "b[personal-transport]-c[heli]",
+    place_result = "heli-placement-entity-_-",
+    stack_size = 1
+  }
 })

--- a/prototypes/items/heli_k2_anti_material_gun.lua
+++ b/prototypes/items/heli_k2_anti_material_gun.lua
@@ -3,44 +3,44 @@ if not mods["Krastorio2"] or not data.raw["ammo-category"]["anti-material-rifle-
 end
 
 local anti_material_rifle_shot_sound = {
-	variations = {
-	  {
-		filename = "__Krastorio2Assets__/sounds/weapons/advanced-tank-anti-material-rifle-1.ogg",
-		volume = 0.35,
-	  },
-	  {
-		filename = "__Krastorio2Assets__/sounds/weapons/advanced-tank-anti-material-rifle-2.ogg",
-		volume = 0.35,
-	  },
-	},
-	aggregation = {
-	  max_count = 2,
-	  remove = false,
-	  count_already_playing = true,
-	},
+  variations = {
+    {
+    filename = "__Krastorio2Assets__/sounds/weapons/advanced-tank-anti-material-rifle-1.ogg",
+    volume = 0.35,
+    },
+    {
+    filename = "__Krastorio2Assets__/sounds/weapons/advanced-tank-anti-material-rifle-2.ogg",
+    volume = 0.35,
+    },
+  },
+  aggregation = {
+    max_count = 2,
+    remove = false,
+    count_already_playing = true,
+  },
   }
 
 data:extend({
-	{
-	type = "gun",
-	name = "heli-k2-anti-material-gun",
-	icon = "__HelicopterRevival__/graphics/icons/anti-material-rifle.png",
-	icon_size = 64,
-	flags = {},
-	subgroup = "gun",
-	order = "d[heli-k2-anti-material-gun]",
-	attack_parameters =
-	{
-		type = "projectile",
-		ammo_category = "anti-material-rifle-ammo",
-		movement_slow_down_factor = 1.2,
-		cooldown = 20,
-		damage_modifier = settings.startup["heli-k2-anti-material-gun-damage-modifier"].value,
-		projectile_creation_distance = 0.6,
-		range = settings.startup["heli-k2-anti-material-gun-range"].value,
-		projectile_center = {-0.17, 0},
-		sound = anti_material_rifle_shot_sound
-	},
-	stack_size = 1
-	},
+  {
+  type = "gun",
+  name = "heli-k2-anti-material-gun",
+  icon = "__HelicopterRevival__/graphics/icons/anti-material-rifle.png",
+  icon_size = 64,
+  flags = {},
+  subgroup = "gun",
+  order = "d[heli-k2-anti-material-gun]",
+  attack_parameters =
+  {
+    type = "projectile",
+    ammo_category = "anti-material-rifle-ammo",
+    movement_slow_down_factor = 1.2,
+    cooldown = 20,
+    damage_modifier = settings.startup["heli-k2-anti-material-gun-damage-modifier"].value,
+    projectile_creation_distance = 0.6,
+    range = settings.startup["heli-k2-anti-material-gun-range"].value,
+    projectile_center = {-0.17, 0},
+    sound = anti_material_rifle_shot_sound
+  },
+  stack_size = 1
+  },
 })

--- a/prototypes/items/heli_rocket_launcher_item.lua
+++ b/prototypes/items/heli_rocket_launcher_item.lua
@@ -1,30 +1,30 @@
 data:extend({
-	{
-	type = "gun",
-	name = "heli-rocket-launcher-item",
-	icon = "__HelicopterRevival__/graphics/icons/rocket_pod.png",
-	icon_size = 64,
-	flags = {},
-	subgroup = "gun",
-	order = "d[rocket-launcher]",
-	attack_parameters =
-	{
-		type = "projectile",
-		ammo_category = "rocket",
-		movement_slow_down_factor = 1.2,
-		cooldown = 20,
-		damage_modifier = settings.startup["heli-rocket-damage-modifier"].value,
-		projectile_creation_distance = 0.6,
-		range = settings.startup["heli-rocket-launcher-range"].value,
-		projectile_center = {-0.17, 0},
-		sound =
-		{
-			{
-				filename = "__base__/sound/fight/rocket-launcher.ogg",
-				volume = 0.7
-			}
-		}
-	},
-	stack_size = 50
-	},
+  {
+  type = "gun",
+  name = "heli-rocket-launcher-item",
+  icon = "__HelicopterRevival__/graphics/icons/rocket_pod.png",
+  icon_size = 64,
+  flags = {},
+  subgroup = "gun",
+  order = "d[rocket-launcher]",
+  attack_parameters =
+  {
+    type = "projectile",
+    ammo_category = "rocket",
+    movement_slow_down_factor = 1.2,
+    cooldown = 20,
+    damage_modifier = settings.startup["heli-rocket-damage-modifier"].value,
+    projectile_creation_distance = 0.6,
+    range = settings.startup["heli-rocket-launcher-range"].value,
+    projectile_center = {-0.17, 0},
+    sound =
+    {
+      {
+        filename = "__base__/sound/fight/rocket-launcher.ogg",
+        volume = 0.7
+      }
+    }
+  },
+  stack_size = 50
+  },
 })

--- a/prototypes/recipes/heli_recipe.lua
+++ b/prototypes/recipes/heli_recipe.lua
@@ -1,16 +1,16 @@
 data:extend({
-	{
-		type = "recipe",
-		name = "heli-recipe",
-		enabled = false,
-		ingredients = {
-			{"engine-unit", 150},
-			{"steel-plate", 150},
-			{"iron-gear-wheel", 250},
-			{"processing-unit", 250},
-			{"gun-turret", 10},
-			{"rocket-launcher", 10},
-		},
-		result = "heli-item",
-	}
+  {
+    type = "recipe",
+    name = "heli-recipe",
+    enabled = false,
+    ingredients = {
+      {"engine-unit", 150},
+      {"steel-plate", 150},
+      {"iron-gear-wheel", 250},
+      {"processing-unit", 250},
+      {"gun-turret", 10},
+      {"rocket-launcher", 10},
+    },
+    result = "heli-item",
+  }
 })

--- a/prototypes/recipes/remote_recipes.lua
+++ b/prototypes/recipes/remote_recipes.lua
@@ -1,25 +1,25 @@
 data:extend({
-	{
-		type = "recipe",
-		name = "heli-remote-recipe",
-		enabled = false,
-		energy_required = 15,
-		ingredients = {
-			{"processing-unit", 125},
-			{"battery", 50},
-			{"plastic-bar", 40},
-			{"iron-stick", 2},
-		},
-		result = "heli-remote-equipment",
-	},
-	{
-		type = "recipe",
-		name = "heli-pad-recipe",
-		enabled = false,
-		energy_required = 5,
-		ingredients = {
-			{"refined-concrete", 50},
-		},
-		result = "heli-pad-item",
-	},
+  {
+    type = "recipe",
+    name = "heli-remote-recipe",
+    enabled = false,
+    energy_required = 15,
+    ingredients = {
+      {"processing-unit", 125},
+      {"battery", 50},
+      {"plastic-bar", 40},
+      {"iron-stick", 2},
+    },
+    result = "heli-remote-equipment",
+  },
+  {
+    type = "recipe",
+    name = "heli-pad-recipe",
+    enabled = false,
+    energy_required = 5,
+    ingredients = {
+      {"refined-concrete", 50},
+    },
+    result = "heli-pad-item",
+  },
 })

--- a/prototypes/signals/signals.lua
+++ b/prototypes/signals/signals.lua
@@ -1,20 +1,20 @@
 data:extend(
 {
-	{
-		type = "virtual-signal",
-		name = "signal-heli-fuel-warning",
-		icon = "__HelicopterRevival__/graphics/icons/fuel_warning.png",
-		icon_size = 64,
-		subgroup = "virtual-signal-number",
-		order = "e[warnings]-[1]"
-	},
+  {
+    type = "virtual-signal",
+    name = "signal-heli-fuel-warning",
+    icon = "__HelicopterRevival__/graphics/icons/fuel_warning.png",
+    icon_size = 64,
+    subgroup = "virtual-signal-number",
+    order = "e[warnings]-[1]"
+  },
 
-	{
-		type = "virtual-signal",
-		name = "signal-heli-fuel-warning-critical",
-		icon = "__core__/graphics/icons/alerts/fuel-icon-red.png",
-		icon_size = 64,
-		subgroup = "virtual-signal-number",
-		order = "e[warnings]-[2]"
-	},
+  {
+    type = "virtual-signal",
+    name = "signal-heli-fuel-warning-critical",
+    icon = "__core__/graphics/icons/alerts/fuel-icon-red.png",
+    icon_size = 64,
+    subgroup = "virtual-signal-number",
+    order = "e[warnings]-[2]"
+  },
 })

--- a/prototypes/sounds/sounds.lua
+++ b/prototypes/sounds/sounds.lua
@@ -1,8 +1,8 @@
 data:extend({
-	{
-		type = "sound",
-		name = "heli-fuel-warning",
-		filename = "__HelicopterRevival__/sound/fuel_warning.ogg",
-		volume = 0.5,
-	},
+  {
+    type = "sound",
+    name = "heli-fuel-warning",
+    filename = "__HelicopterRevival__/sound/fuel_warning.ogg",
+    volume = 0.5,
+  },
 })

--- a/prototypes/sprites/sprites.lua
+++ b/prototypes/sprites/sprites.lua
@@ -100,14 +100,14 @@ data:extend({
 gauge_pointers = {}
 
 for i = 0, 127 do
-	table.insert(gauge_pointers, {
-		type = "sprite",
+  table.insert(gauge_pointers, {
+    type = "sprite",
     name = "heli_gauge_pointer_" .. tostring(i),
     filename = "__HelicopterRevival__/graphics/gui/gauges/pointers/pointer-" .. tostring(i) .. ".png",
     priority = "medium",
     width = 128,
     height = 128,
-	})
+  })
 end
 
 data:extend(gauge_pointers)

--- a/prototypes/technologies/heli_technology.lua
+++ b/prototypes/technologies/heli_technology.lua
@@ -17,9 +17,9 @@ data:extend({
       count = 400,
       ingredients =
       {
-						{"automation-science-pack", 1},
-						{"logistic-science-pack", 1},
-						{"chemical-science-pack", 2},
+            {"automation-science-pack", 1},
+            {"logistic-science-pack", 1},
+            {"chemical-science-pack", 2},
       },
       time = 30
     },

--- a/prototypes/technologies/remote_technology.lua
+++ b/prototypes/technologies/remote_technology.lua
@@ -21,9 +21,9 @@ data:extend({
       count = 450,
       ingredients =
       {
-		{"automation-science-pack", 1},
-		{"logistic-science-pack", 1},
-		{"chemical-science-pack", 2},
+    {"automation-science-pack", 1},
+    {"logistic-science-pack", 1},
+    {"chemical-science-pack", 2},
         {"utility-science-pack", 2},
       },
       time = 35

--- a/settings.lua
+++ b/settings.lua
@@ -56,7 +56,27 @@ data:extend({
         default_value = 70,
         minimum_value = 0,
     },
-
+    ------------------------------
+    -- Take damage settings
+    ------------------------------
+    {
+        type = "bool-setting",
+        name = "heli-disable-biters-damage",
+        setting_type = "runtime-global",
+        default_value = true,
+    },
+    {
+        type = "bool-setting",
+        name = "heli-disable-acid-splash-damage",
+        setting_type = "runtime-global",
+        default_value = true,
+    },
+    {
+        type = "bool-setting",
+        name = "heli-disable-direct-spitter-damage",
+        setting_type = "runtime-global",
+        default_value = false,
+    },
     ------------------------------
     {
         type = "string-setting",


### PR DESCRIPTION
This change adds these configurable options:
* Disable damage from biters (in flight) - **default: on**
* Disable damage from acid puddles (in flight) - **default: on**
* Disable damage from spitter projectiles (in flight) - **default: off**

It doesn't make sense for a flying helicopter to take damage from acid puddles on the ground, or biters melee attacks. 

Also replaced all tabs with spaces.