### PR TITLE
Fix ground acid puddles using trigger_target_mask

### DIFF
--- a/logic/heliBase.lua
+++ b/logic/heliBase.lua
@@ -551,16 +551,8 @@ heliBase = {
 					-- unit doesn't have attack_parameters, that is strange          
 				end
 		else
-			-- not a unit, could be an acid puddle
-			if string.find(cause.name, "acid-splash-fire", 1, true) then
-				-- stepped on an acid puddle
-				if settings.global["heli-disable-acid-splash-damage"].value then
-					cancelDamage = true
-				end
-	        else
-				-- unknown entity, which is not a unit
-				-- game.print("NOT UNIT ("..damage_type..") - Heli damaged by: " .. cause.name .. " (type: " .. cause.type .. ")" .. " damage: " .. damage_amount .. " health: " .. finalHealth)
-			end
+			-- unknown entity, which is not a unit
+			-- game.print("NOT UNIT ("..damage_type..") - Heli damaged by: " .. cause.name .. " (type: " .. cause.type .. ")" .. " damage: " .. damage_amount .. " health: " .. finalHealth)
 		end
     else
 		if damage_type == "acid" then

--- a/prototypes/entities/heli_entity.lua
+++ b/prototypes/entities/heli_entity.lua
@@ -91,6 +91,8 @@ data:extend({
     icon = "__HelicopterRevival__/graphics/icons/heli.png",
     icon_size = 64,
     flags = {"placeable-off-grid", "player-creation"},
+    -- The default for "car" type includes "ground-unit",
+    -- which causes acid puddle DOT moving over a puddle.
     trigger_target_mask = { "common" },
     has_belt_immunity = true,
     minable = {mining_time = 1, result = "heli-item"},

--- a/prototypes/entities/heli_entity.lua
+++ b/prototypes/entities/heli_entity.lua
@@ -91,6 +91,7 @@ data:extend({
     icon = "__HelicopterRevival__/graphics/icons/heli.png",
     icon_size = 64,
     flags = {"placeable-off-grid", "player-creation"},
+    trigger_target_mask = { "common" },
     has_belt_immunity = true,
     minable = {mining_time = 1, result = "heli-item"},
     max_health = 2500,

--- a/settings.lua
+++ b/settings.lua
@@ -67,12 +67,6 @@ data:extend({
     },
     {
         type = "bool-setting",
-        name = "heli-disable-acid-splash-damage",
-        setting_type = "runtime-global",
-        default_value = true,
-    },
-    {
-        type = "bool-setting",
         name = "heli-disable-direct-spitter-damage",
         setting_type = "runtime-global",
         default_value = false,


### PR DESCRIPTION
- Changes the entity to remove `ground-unit`, preventing acid puddle DOT from applying.
- Cleans up the corresponding damage rollback logic, as it shouldn't happen anymore.

Previously, the damage rollback logic wasn't being applied to shields in the helicopter grid.  (Playing in SpaceExploration with armor equipment in the grid still drained the armor, even if the hull didn't take the damage.)

My preference is to remove the settings option in order to simplify the damage logic, as it doesn't make much sense to enable anyway.  However, let me know if you'd prefer a version that retains the setting as a startup config, and I'll be happy to rewrite it.